### PR TITLE
fix(storage): enforce interrupted write cleanup contract

### DIFF
--- a/developer-docs/zh-CN/design/upload-finalization-contracts.md
+++ b/developer-docs/zh-CN/design/upload-finalization-contracts.md
@@ -163,6 +163,16 @@ Relay PUT 返回错误时不能直接假设失败：provider offset 已越过当
 | provider relay resumable | session status `uploading`；Init 创建 provider upload session，upload URL 只加密留在服务端；浏览器 chunk 由 Primary 顺序流式转发到 provider range PUT | 每个请求体必须等于 expected chunk size；provider `nextExpectedRanges` / 最终对象存在性是 range 是否提交的事实源；complete 再校验最终 metadata size | chunk claim、receipt 和 `received_count` 通过共享 writer DB 事务顺序推进；最终 quota 仍由 `finalize_upload_session_file` 原子落账 | `provider_relay::upload_payload` / `upload_bytes` -> `complete_provider_resumable_upload` -> `finalize_verified_opaque_upload_session` -> `finalize_upload_session_file` | DB 唯一 claim + heartbeat 防止多 Primary 重复 PUT；模糊响应先 query provider 再决定补 receipt、释放 claim或保留待对账；取消/过期先 abort provider session 再删临时对象；completed retry 返回已有文件 |
 | remote/follower upload transports | remote policy 通过 remote driver 暴露 direct、presigned、presigned multipart 或 relay multipart；session 状态和 `object_temp_key` / `object_multipart_id` 与对应 object-storage transport 相同 | direct relay 使用 streaming direct metadata；remote presigned single 使用 temp/final metadata；remote presigned multipart 和 remote relay multipart 使用 provider part details + final metadata | 与实际选择的 transport 相同；remote relay direct 走 `store_preuploaded_nondedup`，remote presigned / multipart 走 upload session finalize | `init_remote_upload` 只选择 transport；完成阶段复用 `upload_streaming_direct`、`complete_presigned_upload`、`complete_presigned_multipart` 或 `complete_relay_multipart` | cleanup/idempotency 继承实际 transport；remote/follower 的特殊性只在 driver/protocol 层，产品层不应新增一套平行 finalize 语义 |
 
+### Streaming driver 的中断写入合同
+
+`StreamUploadDriver::put_reader` 返回成功前，最终对象 key 必须只表示完整、已校验的 payload；reader error、连接断开、声明大小不匹配、flush/close 失败和进程 shutdown 都不得把半对象暴露在最终 key：
+
+- SFTP 先写同目录的随机临时 key，关闭并 flush 后再执行 rename；失败路径删除临时 key，已有同名对象保持不变。
+- Azure Blob 的流式路径使用未提交 block；分片、长度校验或 block-list commit 失败时调用 multipart abort。Azure 没有逐 block 删除 API，abort 的语义是让未提交 block 进入 provider 的过期回收范围；这些 block 不得被当成可见对象。
+- reverse follower `put_object` 在 relay 或目标 driver 返回错误时删除目标 key，并记录结构化 cleanup 失败日志；成功响应只在 relay 完整结束且目标写入成功后返回。
+
+重试同一 key 时必须重新建立独立的临时/未提交状态；调用方只能读到旧的完整对象或新的完整对象，不能读到上一次中断留下的半对象。
+
 ## session status 与完成计划
 
 `upload::complete::plan::determine_completion_plan` 使用已解析的 `UploadSessionKind` 选择完成计划；session 状态只负责幂等、assembling、过期和失败错误：

--- a/src/api/routes/internal_storage.rs
+++ b/src/api/routes/internal_storage.rs
@@ -62,6 +62,12 @@ fn validate_ingress_object_size(size: i64, max_file_size: i64, subject: &str) ->
     Ok(())
 }
 
+fn should_cleanup_failed_follower_target(existed_before_upload: Option<bool>) -> bool {
+    // Unknown snapshots are intentionally retained: deleting on an uncertain
+    // read could destroy a complete object that predates this request.
+    existed_before_upload == Some(false)
+}
+
 fn internal_storage_validation_error(
     api_code: ApiErrorCode,
     message: impl Into<String>,
@@ -467,6 +473,22 @@ async fn put_object(
         "follower object write accepted"
     );
 
+    // A failed replacement must not delete an older complete object.  Drivers
+    // with atomic staging (SFTP, local, object PUT) leave this object untouched;
+    // the snapshot also keeps the generic relay cleanup from destroying it.
+    let target_existed_before_upload = match ctx.ingress_driver.exists(&storage_path).await {
+        Ok(exists) => Some(exists),
+        Err(error) => {
+            tracing::warn!(
+                binding_id = ctx.binding.id,
+                object_key = %object_key,
+                storage_path = %storage_path,
+                "failed to snapshot follower target before write: {error}"
+            );
+            None
+        }
+    };
+
     let stream_driver = ctx
         .ingress_driver
         .extensions()
@@ -510,8 +532,31 @@ async fn put_object(
         })
         .await?;
 
-    upload_result?;
-    let etag = relay_result?;
+    let cleanup_target = async {
+        if !should_cleanup_failed_follower_target(target_existed_before_upload) {
+            return;
+        }
+        if let Err(error) = ctx.ingress_driver.delete(&storage_path).await {
+            tracing::warn!(
+                binding_id = ctx.binding.id,
+                object_key = %object_key,
+                storage_path = %storage_path,
+                "failed to cleanup interrupted follower object write: {error}"
+            );
+        }
+    };
+
+    if let Err(error) = upload_result {
+        cleanup_target.await;
+        return Err(error);
+    }
+    let etag = match relay_result {
+        Ok(etag) => etag,
+        Err(error) => {
+            cleanup_target.await;
+            return Err(error);
+        }
+    };
     tracing::info!(
         binding_id = ctx.binding.id,
         object_key = %object_key,
@@ -1107,5 +1152,12 @@ mod tests {
             content_length_header(&headers).expect("valid content-length should parse"),
             42
         );
+    }
+
+    #[test]
+    fn failed_follower_cleanup_only_targets_objects_created_by_this_request() {
+        assert!(should_cleanup_failed_follower_target(Some(false)));
+        assert!(!should_cleanup_failed_follower_target(Some(true)));
+        assert!(!should_cleanup_failed_follower_target(None));
     }
 }

--- a/src/storage/drivers/azure_blob/multipart.rs
+++ b/src/storage/drivers/azure_blob/multipart.rs
@@ -15,7 +15,7 @@ use tokio::io::{AsyncRead, ReadBuf};
 use aster_drive_storage::traits::driver::StorageDriver;
 use aster_drive_storage::traits::extensions::StreamUploadDriver;
 use aster_drive_storage::traits::multipart::{MultipartStorageDriver, UploadedMultipartPart};
-use aster_drive_storage::{MapStorageErr, StorageErrorKind, storage_driver_error};
+use aster_drive_storage::{MapStorageErr, StorageError, StorageErrorKind, storage_driver_error};
 use aster_forge_utils::numbers;
 
 use super::AzureBlobDriver;
@@ -406,6 +406,8 @@ impl StreamUploadDriver for AzureBlobDriver {
             return Ok(storage_path.to_string());
         }
 
+        let upload_id = self.create_multipart_upload(storage_path).await?;
+
         while remaining > 0 {
             let read_limit = numbers::u64_to_usize(
                 remaining.min(
@@ -426,10 +428,10 @@ impl StreamUploadDriver for AzureBlobDriver {
                 })?,
                 Arc::clone(&ended_early),
             );
-            let marker = self
+            let marker = match self
                 .upload_multipart_part_reader(
                     storage_path,
-                    "",
+                    &upload_id,
                     part_number,
                     Box::new(chunk_reader),
                     i64::try_from(read_limit).map_err(|error| {
@@ -449,7 +451,14 @@ impl StreamUploadDriver for AzureBlobDriver {
                     } else {
                         error
                     }
-                })?;
+                }) {
+                Ok(marker) => marker,
+                Err(error) => {
+                    return Err(self
+                        .abort_stream_upload_after_error(storage_path, &upload_id, error)
+                        .await);
+                }
+            };
             parts.push((part_number, marker));
             remaining -= u64::try_from(read_limit).map_err(|error| {
                 storage_driver_error(
@@ -466,7 +475,7 @@ impl StreamUploadDriver for AzureBlobDriver {
         }
 
         let mut extra = [0_u8; 1];
-        let extra_read = tokio::io::AsyncReadExt::read(
+        let extra_read = match tokio::io::AsyncReadExt::read(
             &mut AzureChunkReader::new(Arc::clone(&reader), 1, Arc::new(AtomicBool::new(false))),
             &mut extra,
         )
@@ -474,16 +483,35 @@ impl StreamUploadDriver for AzureBlobDriver {
         .map_storage_err_ctx(
             StorageErrorKind::Precondition,
             "check Azure Blob upload stream length",
-        )?;
+        ) {
+            Ok(read) => read,
+            Err(error) => {
+                return Err(self
+                    .abort_stream_upload_after_error(storage_path, &upload_id, error)
+                    .await);
+            }
+        };
         if extra_read != 0 {
-            return Err(storage_driver_error(
-                StorageErrorKind::Precondition,
-                "Azure Blob upload stream exceeded declared size",
-            ));
+            return Err(self
+                .abort_stream_upload_after_error(
+                    storage_path,
+                    &upload_id,
+                    storage_driver_error(
+                        StorageErrorKind::Precondition,
+                        "Azure Blob upload stream exceeded declared size",
+                    ),
+                )
+                .await);
         }
 
-        self.complete_multipart_upload(storage_path, "", parts)
-            .await?;
+        if let Err(error) = self
+            .complete_multipart_upload(storage_path, &upload_id, parts)
+            .await
+        {
+            return Err(self
+                .abort_stream_upload_after_error(storage_path, &upload_id, error)
+                .await);
+        }
         Ok(storage_path.to_string())
     }
 
@@ -503,6 +531,23 @@ impl StreamUploadDriver for AzureBlobDriver {
             aster_forge_utils::numbers::u64_to_i64(metadata.len(), "Azure Blob upload file size")
                 .map_storage_err(StorageErrorKind::Misconfigured)?;
         self.put_reader(storage_path, Box::new(file), size).await
+    }
+}
+
+impl AzureBlobDriver {
+    async fn abort_stream_upload_after_error(
+        &self,
+        storage_path: &str,
+        upload_id: &str,
+        error: StorageError,
+    ) -> StorageError {
+        if let Err(cleanup_error) = self.abort_multipart_upload(storage_path, upload_id).await {
+            tracing::warn!(
+                storage_path,
+                "failed to cleanup Azure uncommitted blocks after interrupted stream upload: {cleanup_error}"
+            );
+        }
+        error
     }
 }
 

--- a/src/storage/drivers/sftp.rs
+++ b/src/storage/drivers/sftp.rs
@@ -603,26 +603,67 @@ impl StreamUploadDriver for SftpDriver {
         _size: i64,
     ) -> aster_drive_storage::Result<String> {
         let remote_path = self.full_path(storage_path)?;
+        // Never stream directly into the visible key.  A disconnected reader or
+        // provider-side failure must leave the previous version untouched.
+        let temporary_path = format!(
+            "{remote_path}.aster-upload-{:016x}.tmp",
+            rand::random::<u64>()
+        );
         let mut connection = self.acquire_connection().await?;
         ensure_remote_parent_dir(connection.sftp()?, &remote_path).await?;
         let mut remote_file = connection
             .sftp()?
-            .create(remote_path)
+            .create(temporary_path.clone())
             .await
             .map_err(|error| connection.map_sftp_error("SFTP create failed", error))?;
-        tokio::io::copy(&mut reader, &mut remote_file)
-            .await
-            .map_err(|error| map_io_error("SFTP stream upload failed", error))?;
-        remote_file
-            .flush()
-            .await
-            .map_err(|error| map_io_error("SFTP stream flush failed", error))?;
-        remote_file
-            .shutdown()
-            .await
-            .map_err(|error| map_io_error("SFTP stream close failed", error))?;
-        connection.mark_reusable();
-        Ok(storage_path.to_string())
+
+        let result = async {
+            tokio::io::copy(&mut reader, &mut remote_file)
+                .await
+                .map_err(|error| map_io_error("SFTP stream upload failed", error))?;
+            remote_file
+                .flush()
+                .await
+                .map_err(|error| map_io_error("SFTP stream flush failed", error))?;
+            remote_file
+                .shutdown()
+                .await
+                .map_err(|error| map_io_error("SFTP stream close failed", error))?;
+            replace_sftp_object(&mut connection, &temporary_path, &remote_path, storage_path)
+                .await?;
+            Ok::<(), aster_drive_storage::StorageError>(())
+        }
+        .await;
+
+        match result {
+            Ok(()) => {
+                connection.mark_reusable();
+                Ok(storage_path.to_string())
+            }
+            Err(error) => {
+                // Cleanup is part of the interrupted-write contract.  Preserve
+                // the original upload error while making cleanup failure visible.
+                let cleanup_result = match connection.sftp() {
+                    Ok(sftp) => sftp.remove_file(temporary_path.clone()).await,
+                    Err(_) => return Err(error),
+                };
+                match cleanup_result {
+                    Ok(()) => connection.mark_reusable(),
+                    Err(cleanup_error) if is_sftp_not_found(&cleanup_error) => {
+                        connection.mark_reusable();
+                    }
+                    Err(cleanup_error) => {
+                        let cleanup_error = connection
+                            .map_sftp_error("SFTP temporary object cleanup failed", cleanup_error);
+                        tracing::warn!(
+                            storage_path,
+                            "failed to cleanup interrupted SFTP temporary object: {cleanup_error}"
+                        );
+                    }
+                }
+                Err(error)
+            }
+        }
     }
 
     async fn put_file(
@@ -635,6 +676,68 @@ impl StreamUploadDriver for SftpDriver {
             .map_err(|error| map_io_error("open local upload file failed", error))?;
         self.put_reader(storage_path, Box::new(local_file), -1)
             .await
+    }
+}
+
+async fn replace_sftp_object(
+    connection: &mut SftpConnectionLease,
+    temporary_path: &str,
+    destination_path: &str,
+    storage_path: &str,
+) -> aster_drive_storage::Result<()> {
+    // Servers commonly implement the base SFTP rename as "no overwrite".
+    // Exchange through a backup name so retries can replace an existing complete
+    // object without ever publishing the temporary bytes as the final object.
+    let destination_exists = connection
+        .sftp()?
+        .metadata(destination_path.to_string())
+        .await
+        .is_ok();
+    if !destination_exists {
+        return connection
+            .sftp()?
+            .rename(temporary_path.to_string(), destination_path.to_string())
+            .await
+            .map_err(|error| connection.map_sftp_error("SFTP atomic rename failed", error));
+    }
+
+    let backup_path = format!(
+        "{destination_path}.aster-backup-{:016x}.tmp",
+        rand::random::<u64>()
+    );
+    connection
+        .sftp()?
+        .rename(destination_path.to_string(), backup_path.clone())
+        .await
+        .map_err(|error| connection.map_sftp_error("SFTP backup rename failed", error))?;
+
+    let replacement = connection
+        .sftp()?
+        .rename(temporary_path.to_string(), destination_path.to_string())
+        .await;
+    match replacement {
+        Ok(()) => {
+            if let Err(error) = connection.sftp()?.remove_file(backup_path).await {
+                tracing::warn!(
+                    storage_path,
+                    "failed to cleanup replaced SFTP backup object: {error}"
+                );
+            }
+            Ok(())
+        }
+        Err(error) => {
+            if let Err(restore_error) = connection
+                .sftp()?
+                .rename(backup_path, destination_path.to_string())
+                .await
+            {
+                tracing::error!(
+                    storage_path,
+                    "failed to restore original SFTP object after replacement failure: {restore_error}"
+                );
+            }
+            Err(connection.map_sftp_error("SFTP atomic rename failed", error))
+        }
     }
 }
 

--- a/tests/storage/azure_blob.rs
+++ b/tests/storage/azure_blob.rs
@@ -431,6 +431,10 @@ async fn test_azure_blob_put_reader_length_boundaries_with_azurite() {
         .await
         .expect_err("short stream should fail");
     assert_eq!(short_error.kind(), StorageErrorKind::Precondition);
+    assert!(
+        !driver.exists("short.bin").await.unwrap(),
+        "short stream must not commit a visible blob"
+    );
 
     let long_error = driver
         .put_reader(
@@ -441,6 +445,20 @@ async fn test_azure_blob_put_reader_length_boundaries_with_azurite() {
         .await
         .expect_err("long stream should fail");
     assert_eq!(long_error.kind(), StorageErrorKind::Precondition);
+    assert!(
+        !driver.exists("long.bin").await.unwrap(),
+        "extra bytes must abort uncommitted blocks before commit"
+    );
+
+    driver
+        .put_reader(
+            "long.bin",
+            Box::new(std::io::Cursor::new(b"valid".to_vec())),
+            5,
+        )
+        .await
+        .expect("retrying the same key after an aborted stream should succeed");
+    assert_eq!(driver.get("long.bin").await.unwrap(), b"valid");
 
     let upload_id = driver
         .create_multipart_upload("multipart/reader.bin")

--- a/tests/storage/sftp.rs
+++ b/tests/storage/sftp.rs
@@ -1,11 +1,12 @@
 //! SFTP storage driver integration test using testcontainers.
 
 use std::time::Duration;
+use std::{io::Cursor, pin::Pin, task::Context};
 
 use aster_drive::storage::drivers::sftp::{SftpDriver, SftpDriverConfig, SftpStaticCredentials};
 use aster_drive_storage::{StorageDriver, StorageErrorKind, StreamUploadDriver};
 use testcontainers::{GenericImage, ImageExt, core::IntoContainerPort, runners::AsyncRunner};
-use tokio::io::AsyncReadExt as _;
+use tokio::io::{AsyncRead, AsyncReadExt as _, ReadBuf};
 
 const SFTP_IMAGE: &str = "lscr.io/linuxserver/openssh-server";
 const SFTP_TAG: &str = "10.2_p1-r0-ls229";
@@ -13,6 +14,31 @@ const SFTP_PORT: u16 = 2222;
 const SFTP_USERNAME: &str = "aster";
 const SFTP_PASSWORD: &str = "asterpass";
 const SFTP_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
+
+struct FailingReader {
+    prefix: Cursor<Vec<u8>>,
+    failed: bool,
+}
+
+impl AsyncRead for FailingReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        if !self.failed {
+            let mut prefix = [0_u8; 4];
+            let read = std::io::Read::read(&mut self.prefix, &mut prefix).expect("read prefix");
+            buffer.put_slice(&prefix[..read]);
+            self.failed = true;
+            return std::task::Poll::Ready(Ok(()));
+        }
+        std::task::Poll::Ready(Err(std::io::Error::new(
+            std::io::ErrorKind::ConnectionReset,
+            "synthetic peer disconnect",
+        )))
+    }
+}
 
 fn sftp_driver(endpoint: &str, base_path: &str, host_key_fingerprint: Option<&str>) -> SftpDriver {
     SftpDriver::new(
@@ -273,6 +299,54 @@ async fn test_sftp_driver_upload_download_round_trip() {
         driver.get("stream/reader.bin").await.unwrap(),
         b"stream upload"
     );
+
+    // A reader failure must not expose a partial replacement at the final key.
+    driver
+        .put("stream/atomic.bin", b"previous version")
+        .await
+        .unwrap();
+    let error = driver
+        .put_reader(
+            "stream/atomic.bin",
+            Box::new(FailingReader {
+                prefix: Cursor::new(b"partial".to_vec()),
+                failed: false,
+            }),
+            64,
+        )
+        .await
+        .expect_err("interrupted SFTP upload should fail");
+    assert_eq!(error.kind(), StorageErrorKind::Transient);
+    assert_eq!(
+        driver.get("stream/atomic.bin").await.unwrap(),
+        b"previous version"
+    );
+    driver
+        .put_reader(
+            "stream/atomic.bin",
+            Box::new(Cursor::new(b"replacement".to_vec())),
+            11,
+        )
+        .await
+        .expect("a complete retry should atomically replace the old version");
+    assert_eq!(
+        driver.get("stream/atomic.bin").await.unwrap(),
+        b"replacement"
+    );
+
+    let missing_error = driver
+        .put_reader(
+            "stream/never-committed.bin",
+            Box::new(FailingReader {
+                prefix: Cursor::new(b"partial".to_vec()),
+                failed: false,
+            }),
+            64,
+        )
+        .await
+        .expect_err("interrupted new SFTP upload should fail");
+    assert_eq!(missing_error.kind(), StorageErrorKind::Transient);
+    assert!(!driver.exists("stream/never-committed.bin").await.unwrap());
 
     let temp_dir = std::env::temp_dir().join(format!("asterdrive-sftp-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&temp_dir).expect("create temp dir");


### PR DESCRIPTION
## 背景
Issue #555 要求 reverse tunnel、follower relay 和各 storage driver 对中断写入给出一致的原子提交与清理语义，避免连接断开、reader error、shutdown 或重试后读到半对象。

## 改动
- SFTP 流式写入改为同目录临时对象，完成 flush/close 后再提交到正式 key；覆盖已有对象时使用 backup exchange，失败时恢复旧对象并清理临时对象。
- Azure Blob 流式 multipart 使用显式 upload id；分片、长度校验和 commit 失败统一 abort 未提交 block。
- reverse follower `put_object` 在上传失败时按上传前目标存在性决定清理，避免误删旧的完整对象；未知快照状态保守保留。
- 同步上传完成契约文档，明确 streaming driver 的中断写入合同。

## 测试
- `cargo check -p aster_drive`
- `cargo test -p aster_drive --test storage sftp::test_sftp_driver_upload_download_round_trip -- --nocapture`
- `cargo test -p aster_drive --test storage azure_blob::test_azure_blob_put_reader_length_boundaries_with_azurite -- --nocapture`
- `cargo test -p aster_drive --lib storage::drivers::sftp -- --nocapture`
- `cargo test -p aster_drive --lib storage::drivers::azure_blob::multipart -- --nocapture`
- `cargo test -p aster_drive --lib api::routes::internal_storage::tests -- --nocapture`
- `cargo fmt --all`
- `git diff --check`

Closes #555


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 流式上传现仅在内容完整且校验通过后发布，避免用户看到不完整文件。
  * 上传中断或失败时会自动清理临时数据，减少残留对象。
  * 已存在文件更新失败时保留原版本，确保数据安全。
  * 上传失败后可安全重试同一文件名，成功上传不会受中断影响。

* **文档**
  * 补充流式上传中断处理、失败清理及重试行为说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->