### PR TITLE
perf(release): reduce binary size and fix upload benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2980,6 +2986,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4435,6 +4447,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "277ff51754a3f68f12f58446c5d006aa8baa4914ea273cce24a599cfaff33d4f"
 
 [[package]]
+name = "include-flate"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f173716febb1ad596c16ea5637b5f1790ea32de8e627493ff82bc73b0876ce"
+dependencies = [
+ "include-flate-codegen",
+ "include-flate-compress",
+]
+
+[[package]]
+name = "include-flate-codegen"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a7875b62a72ad3f3203cdd8950d4cf9947db036030b974b8b37ceae90c8d8c0"
+dependencies = [
+ "include-flate-compress",
+ "proc-macro-error3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "include-flate-compress"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fbb9c5ccb9a5b67b4afa2974c27e5507ea1bf6d22828cef418e4dfaeca51dd"
+dependencies = [
+ "libflate",
+ "zstd",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4838,6 +4883,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libflate"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4da9b700e758e57152a1fd1c52cbdc5727c1aa6d8743dc1acda917398f1d76c"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+ "no_std_io2",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
+dependencies = [
+ "hashbrown 0.16.1",
+ "no_std_io2",
+ "rle-decode-fast",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5127,6 +5196,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -6703,6 +6781,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
 name = "roxmltree"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6873,6 +6957,7 @@ version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
 dependencies = [
+ "include-flate",
  "rust-embed-impl",
  "rust-embed-utils",
  "walkdir",
@@ -6899,6 +6984,7 @@ version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
+ "include-flate",
  "sha2 0.11.0",
  "walkdir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,7 +245,7 @@ percent-encoding = "2.3"
 rand = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json"] }
 ring = "0.17"
-rust-embed = { version = "8", features = ["interpolate-folder-path"] }
+rust-embed = { version = "8", features = ["compression", "interpolate-folder-path"] }
 sea-orm = { workspace = true, features = ["sqlx-mysql", "sqlx-postgres", "sqlx-sqlite"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/tests/performance/k6/lib/client.js
+++ b/tests/performance/k6/lib/client.js
@@ -121,7 +121,8 @@ export function refreshSession(session) {
 	});
 	const body = assertApi(response, "auth.refresh", 200);
 	const accessToken = cookieValue(response, "aster_access");
-	const refreshToken = cookieValue(response, "aster_refresh") || session.refreshToken;
+	const refreshToken =
+		cookieValue(response, "aster_refresh") || session.refreshToken;
 	const csrfToken = cookieValue(response, "aster_csrf") || session.csrfToken;
 	if (!accessToken) {
 		fail("auth.refresh did not return an access cookie");
@@ -259,6 +260,7 @@ export function uploadDirect(
 		mimeType = "text/plain",
 		folderId = null,
 		relativePath = null,
+		declaredSize = content.length,
 	},
 ) {
 	const payload = {
@@ -269,6 +271,7 @@ export function uploadDirect(
 			`/api/v1/files/upload${buildQuery({
 				folder_id: folderId,
 				relative_path: relativePath,
+				declared_size: declaredSize,
 			})}`,
 		),
 		payload,


### PR DESCRIPTION
## Summary

- Enable `rust-embed` per-file compression for the embedded frontend release assets.
- Fix the k6 direct-upload benchmark to send `declared_size`, so known-size uploads exercise the direct path instead of the staged fallback.
- Keep the full `server,cli` feature set, O2/LTO, panic unwind, function symbols, and AWS-LC CPU dispatch unchanged.

## Binary-size evidence

On the complete release build (`server,cli`, O2, LTO, unwind):

- Raw ELF: `90,355,680 B -> 86,700,128 B`
- Reduction: `3,655,552 B` (about 4.0%)
- The reduction is in embedded asset data (`.rodata`); application `.text` remains effectively unchanged.

Multipart/upload code was profiled separately and is not the primary raw ELF size source. AWS-LC size mode and broad Actix/SeaORM rewrites were measured as lower-value or higher-risk follow-ups and are intentionally not part of this PR.

## Validation

- `cargo check --release --locked --offline`
- Frontend route focused tests: 5 passed
- Local auth token focused tests: 18 passed
- RustFS S3 integration test: 1 passed
- Release binary runtime smoke and embedded asset HTTP smoke passed
- `git diff --check`

The release archive size is tracked separately from the raw ELF target because per-file embedded compression can change outer archive compression behavior.