### PR TITLE
fix(upload): handle concurrent folder parent initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **目录上传并发初始化事务** — 并发初始化同一新目录下的多个文件时，父目录创建现在使用数据库原生冲突忽略和胜者回读，避免 PostgreSQL 唯一键竞争后复用 aborted transaction 导致第二个文件返回 500；不串行化无关 workspace 的目录创建，并补充并发初始化和多级路径回归覆盖。
 - **认证 flow 过期与重放边界** — contact verification token 的消费现在要求 `consumed_at IS NULL AND expires_at > now`，避免并发窗口消费已过期 token；external callback 在原子消费前验证 active flow，Passkey challenge 使用带 identity、revision 和 expiry 的单次消费 envelope，session refresh 拒绝 expired/revoked session，非法 transition 不再产生部分认证副作用。
 - **Azure Blob loopback 复制回退延迟** — Azurite 等 loopback endpoint 的服务端 URL copy 失败后立即进入本地流式复制回退，不再先耗尽 Azure SDK 的完整重试窗口；非 loopback Azure endpoint 继续保留默认重试策略。
 

--- a/src/db/repository/folder_repo/mod.rs
+++ b/src/db/repository/folder_repo/mod.rs
@@ -12,7 +12,8 @@ pub use common::{
     is_duplicate_name_error, is_name_conflict_db_err, map_bulk_name_db_err, map_name_db_err,
 };
 pub use mutation::{
-    clear_policy_references, create, create_many, delete, delete_many, move_many_to_parent,
+    clear_policy_references, create, create_many, create_or_find_by_name_in_parent,
+    create_or_find_by_name_in_team_parent, delete, delete_many, move_many_to_parent,
 };
 pub(crate) use path::{find_ancestor_models, find_team_ancestor_models};
 pub use path::{find_ancestors, resolve_path_chain};
@@ -22,7 +23,7 @@ pub use query::{
     find_by_name_in_team_parent, find_by_names_in_parent, find_by_names_in_team_parent,
     find_children, find_children_after_id, find_children_in_parents, find_children_paginated,
     find_team_children, find_team_children_after_id, find_team_children_in_parents,
-    find_team_children_paginated, lock_by_id,
+    find_team_children_paginated, lock_by_id, lock_by_name_in_parent, lock_by_name_in_team_parent,
 };
 pub(crate) use query::{find_child_ids_after_id_in_scope, find_child_ids_in_parents};
 pub use trash::{

--- a/src/db/repository/folder_repo/mutation.rs
+++ b/src/db/repository/folder_repo/mutation.rs
@@ -2,13 +2,100 @@
 
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, sea_query::Expr,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, DbBackend, EntityTrait, QueryFilter,
+    TryInsertResult,
+    sea_query::{Expr, OnConflict},
 };
 
 use crate::errors::{AsterError, Result};
 use aster_drive_model::entities::folder::{self, Entity as Folder};
 
-use super::common::{map_bulk_name_db_err, map_name_db_err};
+use super::common::{FolderScope, map_bulk_name_db_err, map_name_db_err};
+
+pub async fn create_or_find_by_name_in_parent<C: ConnectionTrait>(
+    db: &C,
+    model: folder::ActiveModel,
+    user_id: i64,
+    parent_id: Option<i64>,
+    name: &str,
+) -> Result<folder::Model> {
+    create_or_find_in_scope(
+        db,
+        model,
+        FolderScope::Personal { user_id },
+        parent_id,
+        name,
+    )
+    .await
+}
+
+pub async fn create_or_find_by_name_in_team_parent<C: ConnectionTrait>(
+    db: &C,
+    model: folder::ActiveModel,
+    team_id: i64,
+    parent_id: Option<i64>,
+    name: &str,
+) -> Result<folder::Model> {
+    create_or_find_in_scope(db, model, FolderScope::Team { team_id }, parent_id, name).await
+}
+
+async fn create_or_find_in_scope<C: ConnectionTrait>(
+    db: &C,
+    model: folder::ActiveModel,
+    scope: FolderScope,
+    parent_id: Option<i64>,
+    name: &str,
+) -> Result<folder::Model> {
+    if let Some(created) = insert_without_conflict(db, model).await? {
+        return Ok(created);
+    }
+
+    let existing = match scope {
+        FolderScope::Personal { user_id } => {
+            super::query::lock_by_name_in_parent(db, user_id, parent_id, name).await?
+        }
+        FolderScope::Team { team_id } => {
+            super::query::lock_by_name_in_team_parent(db, team_id, parent_id, name).await?
+        }
+    };
+    existing
+        .ok_or_else(|| AsterError::internal_error("folder insert conflict could not be reloaded"))
+}
+
+async fn insert_without_conflict<C: ConnectionTrait>(
+    db: &C,
+    model: folder::ActiveModel,
+) -> Result<Option<folder::Model>> {
+    // The live folder-name index is an expression index, so it cannot be named as a portable
+    // PostgreSQL conflict target. PostgreSQL/SQLite accept an unqualified DO NOTHING. MySQL
+    // uses LAST_INSERT_ID(id) so the duplicate winner remains visible under REPEATABLE READ.
+    match Folder::insert(model)
+        .on_conflict(folder_insert_conflict(db.get_database_backend()))
+        .try_insert()
+        .exec(db)
+        .await
+        .map_err(AsterError::from)?
+    {
+        TryInsertResult::Inserted(result) => Folder::find_by_id(result.last_insert_id)
+            .one(db)
+            .await
+            .map_err(AsterError::from),
+        TryInsertResult::Conflicted => Ok(None),
+        TryInsertResult::Empty => Err(AsterError::internal_error(
+            "folder insert produced no row or conflict result",
+        )),
+    }
+}
+
+fn folder_insert_conflict(backend: DbBackend) -> OnConflict {
+    if backend == DbBackend::MySql {
+        let mut on_conflict = OnConflict::columns([folder::Column::Id]);
+        on_conflict.value(folder::Column::Id, Expr::cust("LAST_INSERT_ID(id)"));
+        on_conflict
+    } else {
+        OnConflict::new().do_nothing().to_owned()
+    }
+}
 
 pub async fn create<C: ConnectionTrait>(
     db: &C,
@@ -88,4 +175,42 @@ pub async fn clear_policy_references<C: ConnectionTrait>(db: &C, policy_id: i64)
         .await
         .map_err(AsterError::from)?;
     Ok(result.rows_affected)
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DbBackend, EntityTrait, QueryTrait, Set};
+
+    use super::{folder, folder_insert_conflict};
+
+    fn insert_sql(backend: DbBackend) -> String {
+        folder::Entity::insert(folder::ActiveModel {
+            name: Set("parallel".to_string()),
+            ..Default::default()
+        })
+        .on_conflict(folder_insert_conflict(backend))
+        .build(backend)
+        .to_string()
+    }
+
+    #[test]
+    fn folder_conflict_clause_is_backend_specific_and_non_failing() {
+        let postgres = insert_sql(DbBackend::Postgres);
+        assert!(
+            postgres.contains("ON CONFLICT") && postgres.contains("DO NOTHING"),
+            "{postgres}"
+        );
+
+        let sqlite = insert_sql(DbBackend::Sqlite);
+        assert!(
+            sqlite.contains("ON CONFLICT") && sqlite.contains("DO NOTHING"),
+            "{sqlite}"
+        );
+
+        let mysql = insert_sql(DbBackend::MySql);
+        assert!(
+            mysql.contains("ON DUPLICATE KEY UPDATE `id` = LAST_INSERT_ID(id)"),
+            "{mysql}"
+        );
+    }
 }

--- a/src/db/repository/folder_repo/query.rs
+++ b/src/db/repository/folder_repo/query.rs
@@ -395,6 +395,24 @@ async fn find_by_name_in_parent_in_scope<C: ConnectionTrait>(
         }))
 }
 
+async fn lock_by_name_in_parent_in_scope<C: ConnectionTrait>(
+    db: &C,
+    scope: FolderScope,
+    parent_id: Option<i64>,
+    name: &str,
+) -> Result<Option<folder::Model>> {
+    Folder::find()
+        .filter(apply_parent_condition(
+            active_scope_condition(scope),
+            parent_id,
+        ))
+        .filter(folder::Column::Name.eq(name))
+        .lock_exclusive()
+        .one(db)
+        .await
+        .map_err(AsterError::from)
+}
+
 async fn find_by_names_in_parent_in_scope<C: ConnectionTrait>(
     db: &C,
     scope: FolderScope,
@@ -488,6 +506,15 @@ pub async fn find_by_name_in_parent<C: ConnectionTrait>(
     find_by_name_in_parent_in_scope(db, FolderScope::Personal { user_id }, parent_id, name).await
 }
 
+pub async fn lock_by_name_in_parent<C: ConnectionTrait>(
+    db: &C,
+    user_id: i64,
+    parent_id: Option<i64>,
+    name: &str,
+) -> Result<Option<folder::Model>> {
+    lock_by_name_in_parent_in_scope(db, FolderScope::Personal { user_id }, parent_id, name).await
+}
+
 pub async fn find_by_names_in_parent<C: ConnectionTrait>(
     db: &C,
     user_id: i64,
@@ -504,6 +531,15 @@ pub async fn find_by_name_in_team_parent<C: ConnectionTrait>(
     name: &str,
 ) -> Result<Option<folder::Model>> {
     find_by_name_in_parent_in_scope(db, FolderScope::Team { team_id }, parent_id, name).await
+}
+
+pub async fn lock_by_name_in_team_parent<C: ConnectionTrait>(
+    db: &C,
+    team_id: i64,
+    parent_id: Option<i64>,
+    name: &str,
+) -> Result<Option<folder::Model>> {
+    lock_by_name_in_parent_in_scope(db, FolderScope::Team { team_id }, parent_id, name).await
 }
 
 pub async fn find_by_names_in_team_parent<C: ConnectionTrait>(

--- a/src/services/workspace/storage_core/path.rs
+++ b/src/services/workspace/storage_core/path.rs
@@ -149,18 +149,8 @@ async fn ensure_folder_in_parent<C: sea_orm::ConnectionTrait>(
                 ..Default::default()
             };
 
-            match folder_repo::create(db, model).await {
-                Ok(created) => Ok(created),
-                Err(err) => {
-                    if let Some(existing) =
-                        folder_repo::find_by_name_in_parent(db, user_id, parent_id, &name).await?
-                    {
-                        Ok(existing)
-                    } else {
-                        Err(err)
-                    }
-                }
-            }
+            folder_repo::create_or_find_by_name_in_parent(db, model, user_id, parent_id, &name)
+                .await
         }
         WorkspaceStorageScope::Team {
             team_id,
@@ -189,19 +179,8 @@ async fn ensure_folder_in_parent<C: sea_orm::ConnectionTrait>(
                 ..Default::default()
             };
 
-            match folder_repo::create(db, model).await {
-                Ok(created) => Ok(created),
-                Err(err) => {
-                    if let Some(existing) =
-                        folder_repo::find_by_name_in_team_parent(db, team_id, parent_id, &name)
-                            .await?
-                    {
-                        Ok(existing)
-                    } else {
-                        Err(err)
-                    }
-                }
-            }
+            folder_repo::create_or_find_by_name_in_team_parent(db, model, team_id, parent_id, &name)
+                .await
         }
     }
 }

--- a/tests/files/directory_upload.rs
+++ b/tests/files/directory_upload.rs
@@ -4,7 +4,10 @@ use crate::common;
 
 use actix_web::test;
 use aster_drive::db::repository::folder_repo;
+use aster_drive::services::{files::upload, workspace::team};
+use aster_drive_model::entities::folder;
 use aster_forge_utils::numbers::i64_to_usize;
+use sea_orm::{ActiveModelTrait, Set};
 use serde_json::Value;
 
 #[actix_web::test]
@@ -282,6 +285,274 @@ async fn test_init_upload_with_relative_path_reuses_existing_directories() {
     let guides = folder_repo::find_by_id(&db, guides_id).await.unwrap();
     assert_eq!(docs.created_by_username, "testuser");
     assert_eq!(guides.created_by_username, "testuser");
+}
+
+#[actix_web::test]
+async fn test_concurrent_init_uploads_share_new_nested_parent_path() {
+    let state = common::setup_with_pool_size(4).await;
+    let app = create_test_app!(state.clone());
+    let user_id =
+        common::setup_test_account_via_api(&app, "testuser", "test@example.com", "password123")
+            .await;
+    let relative_root = format!("parallel-{}/nested", uuid::Uuid::new_v4());
+    let first_path = format!("{relative_root}/first.bin");
+    let second_path = format!("{relative_root}/second.bin");
+
+    let (first, second) = tokio::join!(
+        upload::init_upload(
+            &state,
+            user_id,
+            "first.bin",
+            10_485_760,
+            None,
+            Some(&first_path),
+        ),
+        upload::init_upload(
+            &state,
+            user_id,
+            "second.bin",
+            10_485_760,
+            None,
+            Some(&second_path),
+        ),
+    );
+
+    assert!(
+        first.is_ok(),
+        "first concurrent init should succeed: {}",
+        first
+            .as_ref()
+            .err()
+            .map(ToString::to_string)
+            .unwrap_or_default()
+    );
+    assert!(
+        second.is_ok(),
+        "second concurrent init should reuse the created parents: {}",
+        second
+            .as_ref()
+            .err()
+            .map(ToString::to_string)
+            .unwrap_or_default()
+    );
+
+    let root_name = relative_root
+        .split('/')
+        .next()
+        .expect("parallel path should have a root segment");
+    let root = folder_repo::find_by_name_in_parent(state.writer_db(), user_id, None, root_name)
+        .await
+        .expect("parallel root lookup should succeed")
+        .expect("parallel root should exist");
+    let root_count = folder_repo::find_children(state.writer_db(), user_id, None)
+        .await
+        .expect("parallel root listing should succeed")
+        .into_iter()
+        .filter(|folder| folder.name == root_name)
+        .count();
+    assert_eq!(root_count, 1, "concurrent init must create one root parent");
+    let nested =
+        folder_repo::find_by_name_in_parent(state.writer_db(), user_id, Some(root.id), "nested")
+            .await
+            .expect("parallel nested lookup should succeed")
+            .expect("parallel nested folder should exist");
+    assert_eq!(
+        folder_repo::find_children(state.writer_db(), user_id, Some(root.id))
+            .await
+            .expect("parallel child lookup should succeed")
+            .len(),
+        1,
+        "concurrent init must create one nested parent"
+    );
+    assert_eq!(nested.parent_id, Some(root.id));
+}
+
+#[tokio::test]
+async fn test_concurrent_team_init_uploads_share_new_nested_parent_path() {
+    let state = common::setup_with_pool_size(4).await;
+    let owner = common::create_test_account(
+        &state,
+        "parallel-team",
+        "parallel-team-owner@example.com",
+        "password123",
+    )
+    .await
+    .expect("team owner should be created");
+    let team = team::create_team(
+        &state,
+        owner.id,
+        team::CreateTeamInput {
+            name: "Parallel folder upload team".to_string(),
+            description: None,
+        },
+    )
+    .await
+    .expect("team should be created");
+    let relative_root = format!("parallel-team-{}/nested", uuid::Uuid::new_v4());
+    let first_path = format!("{relative_root}/first.bin");
+    let second_path = format!("{relative_root}/second.bin");
+
+    let (first, second) = tokio::join!(
+        upload::init_upload_for_team(
+            &state,
+            team.id,
+            owner.id,
+            "first.bin",
+            10_485_760,
+            None,
+            Some(&first_path),
+        ),
+        upload::init_upload_for_team(
+            &state,
+            team.id,
+            owner.id,
+            "second.bin",
+            10_485_760,
+            None,
+            Some(&second_path),
+        ),
+    );
+
+    assert!(
+        first.is_ok(),
+        "first concurrent team init should succeed: {}",
+        first
+            .as_ref()
+            .err()
+            .map(ToString::to_string)
+            .unwrap_or_default()
+    );
+    assert!(
+        second.is_ok(),
+        "second concurrent team init should reuse the created parents: {}",
+        second
+            .as_ref()
+            .err()
+            .map(ToString::to_string)
+            .unwrap_or_default()
+    );
+
+    let root_name = relative_root
+        .split('/')
+        .next()
+        .expect("parallel team path should have a root segment");
+    let roots = folder_repo::find_team_children(state.writer_db(), team.id, None)
+        .await
+        .expect("parallel team root listing should succeed");
+    let matching_roots: Vec<_> = roots
+        .iter()
+        .filter(|folder| folder.name == root_name)
+        .collect();
+    assert_eq!(
+        matching_roots.len(),
+        1,
+        "team init must create one root parent"
+    );
+    let root = matching_roots[0];
+    let nested = folder_repo::find_by_name_in_team_parent(
+        state.writer_db(),
+        team.id,
+        Some(root.id),
+        "nested",
+    )
+    .await
+    .expect("parallel team nested lookup should succeed")
+    .expect("parallel team nested folder should exist");
+    assert_eq!(
+        folder_repo::find_team_children(state.writer_db(), team.id, Some(root.id))
+            .await
+            .expect("parallel team child lookup should succeed")
+            .len(),
+        1,
+        "team init must create one nested parent"
+    );
+    assert_eq!(nested.parent_id, Some(root.id));
+}
+
+#[tokio::test]
+async fn test_conflicting_folder_insert_reloads_existing_personal_and_team_parent() {
+    let state = common::setup_with_pool_size(2).await;
+    let owner = common::create_test_account(
+        &state,
+        "folder-conflict",
+        "folder-conflict-owner@example.com",
+        "password123",
+    )
+    .await
+    .expect("folder conflict owner should be created");
+    let now = chrono::Utc::now();
+
+    let personal = folder::ActiveModel {
+        name: Set("personal-conflict-parent".to_string()),
+        owner_user_id: Set(Some(owner.id)),
+        created_by_user_id: Set(Some(owner.id)),
+        created_by_username: Set(owner.username.clone()),
+        created_at: Set(now),
+        updated_at: Set(now),
+        ..Default::default()
+    }
+    .insert(state.writer_db())
+    .await
+    .expect("personal conflict parent should be inserted");
+    let personal_result = folder_repo::create_or_find_by_name_in_parent(
+        state.writer_db(),
+        folder::ActiveModel {
+            name: Set(personal.name.clone()),
+            owner_user_id: Set(Some(owner.id)),
+            created_by_user_id: Set(Some(owner.id)),
+            created_by_username: Set(owner.username.clone()),
+            created_at: Set(now),
+            updated_at: Set(now),
+            ..Default::default()
+        },
+        owner.id,
+        None,
+        &personal.name,
+    )
+    .await
+    .expect("personal conflict should reload the existing parent");
+    assert_eq!(personal_result.id, personal.id);
+
+    let team = team::create_team(
+        &state,
+        owner.id,
+        team::CreateTeamInput {
+            name: "Folder conflict team".to_string(),
+            description: None,
+        },
+    )
+    .await
+    .expect("folder conflict team should be created");
+    let team_folder = folder::ActiveModel {
+        name: Set("team-conflict-parent".to_string()),
+        team_id: Set(Some(team.id)),
+        created_by_user_id: Set(Some(owner.id)),
+        created_by_username: Set(owner.username.clone()),
+        created_at: Set(now),
+        updated_at: Set(now),
+        ..Default::default()
+    }
+    .insert(state.writer_db())
+    .await
+    .expect("team conflict parent should be inserted");
+    let team_result = folder_repo::create_or_find_by_name_in_team_parent(
+        state.writer_db(),
+        folder::ActiveModel {
+            name: Set(team_folder.name.clone()),
+            team_id: Set(Some(team.id)),
+            created_by_user_id: Set(Some(owner.id)),
+            created_by_username: Set(owner.username),
+            created_at: Set(now),
+            updated_at: Set(now),
+            ..Default::default()
+        },
+        team.id,
+        None,
+        &team_folder.name,
+    )
+    .await
+    .expect("team conflict should reload the existing parent");
+    assert_eq!(team_result.id, team_folder.id);
 }
 
 #[actix_web::test]


### PR DESCRIPTION
## Summary

- 修复目录上传并发初始化父目录时 PostgreSQL 事务进入 aborted 状态，导致第二个文件返回 500。
- 将冲突安全的目录创建下沉到 `folder_repo`：PostgreSQL/SQLite 使用无 target `ON CONFLICT DO NOTHING`，MySQL 使用 `LAST_INSERT_ID(id)` duplicate-key 分支。
- 冲突后使用锁定读回读胜者，覆盖 MySQL 默认 `REPEATABLE READ` 快照语义；不引入 workspace 级全局锁。
- 增加多级目录并发 init 回归、三数据库 SQL 方言断言，并更新 `CHANGELOG.md`。

## Root Cause

目录上传的多个 `/api/v1/files/upload/init` 请求会同时执行父目录的先查后建逻辑。唯一键竞争被捕获后，旧实现继续在 PostgreSQL aborted transaction 中查询，触发 `current transaction is aborted`。

MySQL 还存在默认 `REPEATABLE READ` 快照问题，因此冲突分支使用 `SELECT ... FOR UPDATE` 锁定读回读已提交目录。

## Validation

- `cargo check -p aster_drive --tests`
- `cargo clippy -p aster_drive --tests -- -D warnings`
- `cargo nextest run --profile ci --test files directory_upload::test_concurrent_init_uploads_share_new_nested_parent_path`
- `cargo nextest run --profile ci --test files directory_upload::test_init_upload_with_relative_path_reuses_existing_directories directory_upload::test_relative_path_rejects_empty_segment directory_upload::test_init_upload_with_relative_path_uses_parent_folder_policy`
- `ASTER_TEST_DATABASE_BACKEND=postgres cargo nextest run --profile ci --test files directory_upload::test_concurrent_init_uploads_share_new_nested_parent_path`
- `ASTER_TEST_DATABASE_BACKEND=mysql cargo nextest run --profile ci --test files directory_upload::test_concurrent_init_uploads_share_new_nested_parent_path`
- `cargo nextest run --profile ci -p aster_drive --lib db::repository::folder_repo::mutation::tests::folder_conflict_clause_is_backend_specific_and_non_failing`
- `cargo fmt --all -- --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修复并发上传文件时目录初始化失败的问题，避免后续请求返回 500。
  - 支持并行创建同一嵌套路径下的文件，并正确复用已存在的父目录。
  - 个人空间和团队空间的目录创建行为保持一致。

- **测试**
  - 新增并发上传及多级目录场景的回归测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->