### PR TITLE
fix(files): coordinate browser navigation and trash invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Single multipart upload entry point** — Removed the personal and team `POST /files/upload` compatibility entry points and the server-side staged multipart fallback; clients must first initialize an upload session, then submit content via the negotiated data plane.
 
+### Fixed
+
+- **File browser navigation and deleted-folder recovery** — Route navigation now takes priority over concurrent SSE and mutation-completion refreshes, keeping the URL, current folder, breadcrumb, and visible contents aligned. Empty-trash completion uses a scoped aggregate event instead of a full reconciliation signal, while personal and team folder routes recover to the nearest available ancestor (or workspace root) when the current folder is trashed or permanently removed; folder list, info, and ancestor APIs consistently return `folder.not_found` with a readable lifecycle message.
+
 ## [v0.5.1] - 2026-08-24
 
 ### Added

--- a/frontend-panel/src/hooks/useStorageChangeEvents.test.tsx
+++ b/frontend-panel/src/hooks/useStorageChangeEvents.test.tsx
@@ -30,7 +30,7 @@ const mockState = vi.hoisted(() => ({
 			{ id: null, name: "Root" },
 			{ id: 7, name: "Docs" },
 		],
-		navigateTo: vi.fn(),
+		refresh: vi.fn(),
 	},
 	invalidateBlobUrl: vi.fn(),
 	invalidateTextContent: vi.fn(),
@@ -159,7 +159,7 @@ vi.mock("@/stores/fileStore", () => {
 			selector: (state: {
 				breadcrumb: typeof mockState.fileStore.breadcrumb;
 				currentFolderId: number | null;
-				navigateTo: typeof mockState.fileStore.navigateTo;
+				refresh: typeof mockState.fileStore.refresh;
 			}) => T,
 		) => selector(mockState.fileStore),
 		{
@@ -189,8 +189,8 @@ describe("useStorageChangeEvents", () => {
 			{ id: 7, name: "Docs" },
 		];
 		window.history.replaceState(null, "", "/");
-		mockState.fileStore.navigateTo.mockReset();
-		mockState.fileStore.navigateTo.mockResolvedValue(undefined);
+		mockState.fileStore.refresh.mockReset();
+		mockState.fileStore.refresh.mockResolvedValue(undefined);
 		mockState.invalidateBlobUrl.mockReset();
 		mockState.invalidateTextContent.mockReset();
 		mockState.storageRefreshGate.deferStorageRefresh.mockReset();
@@ -237,7 +237,7 @@ describe("useStorageChangeEvents", () => {
 			"/files/11/thumbnail",
 		);
 		await waitFor(() => {
-			expect(mockState.fileStore.navigateTo).toHaveBeenCalledWith(7);
+			expect(mockState.fileStore.refresh).toHaveBeenCalledWith(7);
 		});
 		expect(mockState.auth.refreshUser).not.toHaveBeenCalled();
 		expect(mockState.teamStore.reload).not.toHaveBeenCalled();
@@ -274,7 +274,7 @@ describe("useStorageChangeEvents", () => {
 		expect(mockState.invalidateTextContent).toHaveBeenCalledWith();
 		expect(mockState.auth.refreshUser).toHaveBeenCalledTimes(1);
 		expect(mockState.teamStore.reload).toHaveBeenCalledWith(100);
-		expect(mockState.fileStore.navigateTo).not.toHaveBeenCalled();
+		expect(mockState.fileStore.refresh).not.toHaveBeenCalled();
 	});
 
 	it("handles sync.required without refreshing on subpath search routes", async () => {
@@ -304,7 +304,7 @@ describe("useStorageChangeEvents", () => {
 		});
 		expect(mockState.auth.refreshUser).toHaveBeenCalledTimes(1);
 		expect(mockState.teamStore.reload).toHaveBeenCalledWith(100);
-		expect(mockState.fileStore.navigateTo).not.toHaveBeenCalled();
+		expect(mockState.fileStore.refresh).not.toHaveBeenCalled();
 	});
 
 	it("ignores non-quota events from other workspaces", async () => {
@@ -332,7 +332,7 @@ describe("useStorageChangeEvents", () => {
 		expect(mockState.teamStore.reload).not.toHaveBeenCalled();
 		expect(mockState.invalidateBlobUrl).not.toHaveBeenCalled();
 		expect(mockState.invalidateTextContent).not.toHaveBeenCalled();
-		expect(mockState.fileStore.navigateTo).not.toHaveBeenCalled();
+		expect(mockState.fileStore.refresh).not.toHaveBeenCalled();
 	});
 
 	it("reloads teams for quota-affecting team events from other workspaces", async () => {
@@ -362,7 +362,7 @@ describe("useStorageChangeEvents", () => {
 		});
 		expect(mockState.invalidateBlobUrl).not.toHaveBeenCalled();
 		expect(mockState.invalidateTextContent).not.toHaveBeenCalled();
-		expect(mockState.fileStore.navigateTo).not.toHaveBeenCalled();
+		expect(mockState.fileStore.refresh).not.toHaveBeenCalled();
 	});
 
 	it("refreshes only personal quota for quota-affecting personal events", async () => {
@@ -392,6 +392,44 @@ describe("useStorageChangeEvents", () => {
 			});
 		});
 		expect(mockState.teamStore.reload).not.toHaveBeenCalled();
+	});
+
+	it("publishes purge-all without refreshing a live folder", async () => {
+		const { subscribeStorageChange } = await import("@/lib/storageChangeBus");
+		const listener = vi.fn();
+		const unsubscribe = subscribeStorageChange(listener);
+		const { useStorageChangeEvents } = await import(
+			"@/hooks/useStorageChangeEvents"
+		);
+
+		try {
+			renderHook(() => useStorageChangeEvents());
+			await connectStorageEvents();
+
+			MockEventSource.instances[0]?.emit({
+				kind: "trash.purged_all",
+				workspace: { kind: "personal" },
+				file_ids: [],
+				folder_ids: [],
+				affected_parent_ids: [],
+				root_affected: false,
+				affects_quota: true,
+				storage_delta: -128,
+				at: "2026-04-08T00:00:00Z",
+			});
+
+			await waitFor(() => {
+				expect(listener).toHaveBeenCalledWith(
+					expect.objectContaining({ kind: "trash.purged_all" }),
+				);
+			});
+			expect(mockState.auth.refreshUser).toHaveBeenCalledWith({
+				fields: ["quota"],
+			});
+			expect(mockState.fileStore.refresh).not.toHaveBeenCalled();
+		} finally {
+			unsubscribe();
+		}
 	});
 
 	it("defers folder refresh while the upload queue gate is active", async () => {
@@ -424,7 +462,7 @@ describe("useStorageChangeEvents", () => {
 			);
 		});
 		expect(mockState.storageRefreshGate.deferStorageRefresh).toHaveBeenCalled();
-		expect(mockState.fileStore.navigateTo).not.toHaveBeenCalled();
+		expect(mockState.fileStore.refresh).not.toHaveBeenCalled();
 	});
 
 	it("refreshes the current folder for matching tag assignment events", async () => {
@@ -449,7 +487,7 @@ describe("useStorageChangeEvents", () => {
 		});
 
 		await waitFor(() => {
-			expect(mockState.fileStore.navigateTo).toHaveBeenCalledWith(7);
+			expect(mockState.fileStore.refresh).toHaveBeenCalledWith(7);
 		});
 		expect(mockState.invalidateBlobUrl).not.toHaveBeenCalled();
 		expect(mockState.invalidateTextContent).not.toHaveBeenCalled();
@@ -476,7 +514,7 @@ describe("useStorageChangeEvents", () => {
 			at: "2026-04-08T00:00:00Z",
 		});
 
-		expect(mockState.fileStore.navigateTo).not.toHaveBeenCalled();
+		expect(mockState.fileStore.refresh).not.toHaveBeenCalled();
 	});
 
 	it("publishes tag events without navigating on virtual browser routes", async () => {
@@ -510,7 +548,7 @@ describe("useStorageChangeEvents", () => {
 					expect.objectContaining({ kind: "tag.updated" }),
 				);
 			});
-			expect(mockState.fileStore.navigateTo).not.toHaveBeenCalled();
+			expect(mockState.fileStore.refresh).not.toHaveBeenCalled();
 		} finally {
 			unsubscribe();
 		}
@@ -545,7 +583,7 @@ describe("useStorageChangeEvents", () => {
 		expect(mockState.auth.refreshUser).not.toHaveBeenCalled();
 		expect(mockState.invalidateBlobUrl).not.toHaveBeenCalled();
 		expect(mockState.invalidateTextContent).not.toHaveBeenCalled();
-		expect(mockState.fileStore.navigateTo).not.toHaveBeenCalled();
+		expect(mockState.fileStore.refresh).not.toHaveBeenCalled();
 	});
 
 	it("does not open the event stream when the user disables realtime sync", async () => {
@@ -720,7 +758,7 @@ describe("useStorageChangeEvents", () => {
 			expect(mockState.invalidateTextContent).not.toHaveBeenCalled();
 			expect(mockState.auth.refreshUser).not.toHaveBeenCalled();
 			expect(mockState.teamStore.reload).not.toHaveBeenCalled();
-			expect(mockState.fileStore.navigateTo).not.toHaveBeenCalled();
+			expect(mockState.fileStore.refresh).not.toHaveBeenCalled();
 		} finally {
 			vi.useRealTimers();
 		}
@@ -749,8 +787,8 @@ describe("useStorageChangeEvents", () => {
 			expect(mockState.auth.refreshUser).toHaveBeenCalledTimes(1);
 			expect(mockState.teamStore.reload).toHaveBeenCalledTimes(1);
 			expect(mockState.teamStore.reload).toHaveBeenCalledWith(100);
-			expect(mockState.fileStore.navigateTo).toHaveBeenCalledTimes(1);
-			expect(mockState.fileStore.navigateTo).toHaveBeenCalledWith(7);
+			expect(mockState.fileStore.refresh).toHaveBeenCalledTimes(1);
+			expect(mockState.fileStore.refresh).toHaveBeenCalledWith(7);
 		} finally {
 			vi.useRealTimers();
 		}
@@ -773,7 +811,7 @@ describe("useStorageChangeEvents", () => {
 			expect(mockState.invalidateTextContent).toHaveBeenCalledWith();
 			expect(mockState.auth.refreshUser).toHaveBeenCalledTimes(1);
 			expect(mockState.teamStore.reload).toHaveBeenCalledWith(100);
-			expect(mockState.fileStore.navigateTo).toHaveBeenCalledWith(7);
+			expect(mockState.fileStore.refresh).toHaveBeenCalledWith(7);
 		} finally {
 			vi.useRealTimers();
 		}
@@ -799,7 +837,7 @@ describe("useStorageChangeEvents", () => {
 			expect(
 				mockState.storageRefreshGate.deferStorageRefresh,
 			).toHaveBeenCalledTimes(1);
-			expect(mockState.fileStore.navigateTo).not.toHaveBeenCalled();
+			expect(mockState.fileStore.refresh).not.toHaveBeenCalled();
 			expect(mockState.auth.refreshUser).toHaveBeenCalledTimes(1);
 			expect(mockState.teamStore.reload).toHaveBeenCalledWith(100);
 		} finally {
@@ -825,7 +863,7 @@ describe("useStorageChangeEvents", () => {
 
 			expect(mockState.auth.refreshUser).toHaveBeenCalledTimes(1);
 			expect(mockState.teamStore.reload).toHaveBeenCalledTimes(1);
-			expect(mockState.fileStore.navigateTo).toHaveBeenCalledTimes(1);
+			expect(mockState.fileStore.refresh).toHaveBeenCalledTimes(1);
 
 			MockEventSource.instances[1]?.triggerError();
 			await vi.advanceTimersByTimeAsync(1000);
@@ -833,7 +871,7 @@ describe("useStorageChangeEvents", () => {
 
 			expect(mockState.auth.refreshUser).toHaveBeenCalledTimes(2);
 			expect(mockState.teamStore.reload).toHaveBeenCalledTimes(2);
-			expect(mockState.fileStore.navigateTo).toHaveBeenCalledTimes(2);
+			expect(mockState.fileStore.refresh).toHaveBeenCalledTimes(2);
 		} finally {
 			vi.useRealTimers();
 		}
@@ -857,7 +895,7 @@ describe("useStorageChangeEvents", () => {
 			expect(MockEventSource.instances).toHaveLength(1);
 			expect(mockState.auth.refreshUser).not.toHaveBeenCalled();
 			expect(mockState.teamStore.reload).not.toHaveBeenCalled();
-			expect(mockState.fileStore.navigateTo).not.toHaveBeenCalled();
+			expect(mockState.fileStore.refresh).not.toHaveBeenCalled();
 		} finally {
 			vi.useRealTimers();
 		}

--- a/frontend-panel/src/hooks/useStorageChangeEvents.test.tsx
+++ b/frontend-panel/src/hooks/useStorageChangeEvents.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "@/lib/logger";
 import {
 	clearStorageEventEchoes,
 	rememberStorageEventEcho,
@@ -244,6 +245,41 @@ describe("useStorageChangeEvents", () => {
 
 		hook.unmount();
 		expect(MockEventSource.instances[0]?.close).toHaveBeenCalledTimes(1);
+	});
+
+	it("logs a current-folder refresh failure without navigating to root", async () => {
+		const refreshError = new Error("folder disappeared");
+		mockState.fileStore.refresh.mockRejectedValueOnce(refreshError);
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+		const { useStorageChangeEvents } = await import(
+			"@/hooks/useStorageChangeEvents"
+		);
+
+		try {
+			renderHook(() => useStorageChangeEvents());
+			await connectStorageEvents();
+			MockEventSource.instances[0]?.emit({
+				kind: "file.updated",
+				workspace: { kind: "personal" },
+				file_ids: [],
+				folder_ids: [],
+				affected_parent_ids: [7],
+				root_affected: false,
+				affects_quota: false,
+				storage_delta: null,
+				at: "2026-04-08T00:00:00Z",
+			});
+
+			await waitFor(() => {
+				expect(warn).toHaveBeenCalledWith(
+					"storage event folder refresh failed",
+					refreshError,
+				);
+			});
+			expect(mockState.fileStore.refresh).toHaveBeenCalledWith(7);
+		} finally {
+			warn.mockRestore();
+		}
 	});
 
 	it("handles sync.required without refreshing during search", async () => {

--- a/frontend-panel/src/hooks/useStorageChangeEvents.ts
+++ b/frontend-panel/src/hooks/useStorageChangeEvents.ts
@@ -40,11 +40,11 @@ function currentPathname() {
 }
 
 async function refreshCurrentFolder() {
-	const { currentFolderId, navigateTo } = useFileStore.getState();
+	const { currentFolderId, refresh } = useFileStore.getState();
 	try {
-		await navigateTo(currentFolderId);
-	} catch {
-		await navigateTo(null);
+		await refresh(currentFolderId);
+	} catch (error) {
+		logger.warn("storage event folder refresh failed", error);
 	}
 }
 

--- a/frontend-panel/src/lib/storageMutationCoordinator.test.ts
+++ b/frontend-panel/src/lib/storageMutationCoordinator.test.ts
@@ -108,6 +108,27 @@ describe("storageMutationCoordinator", () => {
 		});
 	});
 
+	it("limits trash purge-all to trash projections and scoped quota refresh", () => {
+		const decision = decideRemoteStorageMutation(
+			storageEvent({
+				kind: "trash.purged_all",
+				file_ids: [],
+				affected_parent_ids: [],
+				affects_quota: true,
+				storage_delta: -128,
+			}),
+			personalContext,
+		);
+
+		expect(decision).toEqual({
+			invalidateAllResourceCaches: false,
+			invalidateFileResourceCacheIds: [],
+			publishToWorkspace: true,
+			refreshCurrentFolder: "none",
+			refreshStorageUsage: "personal_quota",
+		});
+	});
+
 	it("defers folder refresh while the refresh gate is active", () => {
 		const decision = decideRemoteStorageMutation(storageEvent(), {
 			...personalContext,

--- a/frontend-panel/src/lib/storageMutationCoordinator.ts
+++ b/frontend-panel/src/lib/storageMutationCoordinator.ts
@@ -106,6 +106,10 @@ function isFileChangeEvent(event: StorageChangeEventPayload) {
 	return event.kind.startsWith("file.") || event.kind.startsWith("lock.");
 }
 
+function isTrashProjectionEvent(event: StorageChangeEventPayload) {
+	return event.kind === "trash.purged_all";
+}
+
 function hasResourceReference(event: StorageChangeEventPayload) {
 	return (
 		event.root_affected ||
@@ -200,6 +204,16 @@ export function decideRemoteStorageMutation(
 				!isVirtualFileBrowserPath(context.pathname),
 				context.isRefreshGateActive,
 			),
+			refreshStorageUsage,
+		};
+	}
+
+	if (isTrashProjectionEvent(event)) {
+		return {
+			invalidateAllResourceCaches: false,
+			invalidateFileResourceCacheIds: [],
+			publishToWorkspace: true,
+			refreshCurrentFolder: "none",
 			refreshStorageUsage,
 		};
 	}

--- a/frontend-panel/src/pages/FileBrowserPage.test.tsx
+++ b/frontend-panel/src/pages/FileBrowserPage.test.tsx
@@ -109,6 +109,7 @@ const mockState = vi.hoisted(() => ({
 		deleteFile: vi.fn(),
 		deleteFolder: vi.fn(),
 		error: null as string | null,
+		unavailableFolderId: null as number | null,
 		files: [] as Array<Record<string, unknown>>,
 		folders: [] as Array<Record<string, unknown>>,
 		hasMoreFiles: vi.fn(),
@@ -1349,6 +1350,7 @@ describe("FileBrowserPage", () => {
 		];
 		mockState.store.currentFolderId = 12;
 		mockState.store.error = null;
+		mockState.store.unavailableFolderId = null;
 		mockState.store.files = [createFile()];
 		mockState.store.folders = [createFolder()];
 		mockState.store.hasMoreFiles.mockReturnValue(false);
@@ -1444,6 +1446,56 @@ describe("FileBrowserPage", () => {
 		expect(mockState.store.setSortBy).toHaveBeenCalledWith("updated_at");
 		expect(mockState.store.setSortOrder).toHaveBeenCalledWith("desc");
 	});
+
+	it.each([
+		[{ kind: "personal" } as const, "/folder/3?name=Projects"],
+		[{ kind: "team", teamId: 9 } as const, "/teams/9/folder/3?name=Projects"],
+	])(
+		"recovers an unavailable current folder in %j to its nearest ancestor",
+		async (workspace, expectedPath) => {
+			mockState.workspace = workspace;
+			mockState.store.breadcrumb = [
+				{ id: null, name: "Root" },
+				{ id: 3, name: "Projects" },
+				{ id: 12, name: "Removed" },
+			];
+			mockState.store.unavailableFolderId = 12;
+
+			render(<FileBrowserPage />);
+
+			await waitFor(() => {
+				expect(mockState.navigate).toHaveBeenCalledWith(expectedPath, {
+					replace: true,
+				});
+			});
+			expect(mockState.toastError).toHaveBeenCalledWith(
+				"errors:folder_not_found",
+			);
+		},
+	);
+
+	it.each([
+		[{ kind: "personal" } as const, "/"],
+		[{ kind: "team", teamId: 9 } as const, "/teams/9"],
+	])(
+		"recovers an unavailable folder without a known ancestor in %j to the workspace root",
+		async (workspace, expectedPath) => {
+			mockState.workspace = workspace;
+			mockState.store.breadcrumb = [{ id: null, name: "Root" }];
+			mockState.store.unavailableFolderId = 12;
+
+			render(<FileBrowserPage />);
+
+			await waitFor(() => {
+				expect(mockState.navigate).toHaveBeenCalledWith(expectedPath, {
+					replace: true,
+				});
+			});
+			expect(mockState.toastError).toHaveBeenCalledWith(
+				"errors:folder_not_found",
+			);
+		},
+	);
 
 	it("does not expose folder policy management to regular users", () => {
 		render(<FileBrowserPage />);

--- a/frontend-panel/src/pages/FileBrowserPage.test.tsx
+++ b/frontend-panel/src/pages/FileBrowserPage.test.tsx
@@ -14,7 +14,9 @@ import {
 	consumeStorageEventEcho,
 } from "@/lib/storageEventEcho";
 import FileBrowserPage from "@/pages/FileBrowserPage";
+import { ApiError } from "@/services/http";
 import { useFrontendConfigStore } from "@/stores/frontendConfigStore";
+import { ApiErrorCode } from "@/types/api-helpers";
 
 const mockState = vi.hoisted(() => ({
 	batchDelete: vi.fn(),
@@ -36,6 +38,7 @@ const mockState = vi.hoisted(() => ({
 	fileBrowserContext: null as Record<string, unknown> | null,
 	folderPolicyPreload: vi.fn(),
 	formatBatchToast: vi.fn(),
+	getFolderAncestors: vi.fn(),
 	handleApiError: vi.fn(),
 	idleTasks: [] as Array<() => void>,
 	musicPlayTracks: vi.fn(),
@@ -44,6 +47,8 @@ const mockState = vi.hoisted(() => ({
 		search: "?name=Projects",
 		state: null as Record<string, unknown> | null,
 	},
+	listFolder: vi.fn(),
+	listRoot: vi.fn(),
 	navigate: vi.fn(),
 	params: { folderId: "12" as string | undefined },
 	previewAppStore: {
@@ -1111,11 +1116,15 @@ vi.mock("@/services/fileService", () => ({
 			mockState.createPreviewLink(...args),
 		getArchivePreview: (...args: unknown[]) =>
 			mockState.getArchivePreview(...args),
+		getFolderAncestors: (...args: unknown[]) =>
+			mockState.getFolderAncestors(...args),
 		createWopiSession: (...args: unknown[]) =>
 			mockState.createWopiSession(...args),
 		downloadPath: (id: number) => `/files/${id}/download`,
 		getMediaMetadata: vi.fn(async () => null),
 		imagePreviewPath: (id: number) => `/files/${id}/image-preview`,
+		listFolder: (...args: unknown[]) => mockState.listFolder(...args),
+		listRoot: (...args: unknown[]) => mockState.listRoot(...args),
 		resolveResourceHandle: (...args: unknown[]) =>
 			mockState.resolveResourceHandle(...args),
 		setFileLock: (...args: unknown[]) => mockState.setFileLock(...args),
@@ -1284,6 +1293,7 @@ describe("FileBrowserPage", () => {
 		mockState.fileBrowserContext = null;
 		mockState.folderPolicyPreload.mockReset();
 		mockState.formatBatchToast.mockReset();
+		mockState.getFolderAncestors.mockReset();
 		mockState.handleApiError.mockReset();
 		mockState.idleTasks = [];
 		mockState.musicPlayTracks.mockReset();
@@ -1292,6 +1302,8 @@ describe("FileBrowserPage", () => {
 			search: "?name=Projects",
 			state: null,
 		};
+		mockState.listFolder.mockReset();
+		mockState.listRoot.mockReset();
 		mockState.navigate.mockReset();
 		mockState.previewAppStore.load.mockReset();
 		mockState.thumbnailSupportStore.config = {
@@ -1473,6 +1485,65 @@ describe("FileBrowserPage", () => {
 			);
 		},
 	);
+
+	it("recovers a FolderNotFound raised by the real fileStore navigation chain", async () => {
+		const { useFileStore: realFileStore } =
+			await vi.importActual<typeof import("@/stores/fileStore")>(
+				"@/stores/fileStore",
+			);
+		const notFound = new ApiError(
+			ApiErrorCode.FolderNotFound,
+			"Folder #12 is in trash",
+			{ retryable: false, status: 404 },
+		);
+		mockState.listFolder.mockRejectedValueOnce(notFound);
+		mockState.getFolderAncestors.mockResolvedValueOnce([
+			{ id: 3, name: "Projects" },
+		]);
+		realFileStore.getState().resetWorkspaceState();
+		realFileStore.setState({
+			breadcrumb: [
+				{ id: null, name: "Root" },
+				{ id: 3, name: "Projects" },
+			],
+			currentFolderId: 3,
+		});
+		mockState.store.breadcrumb = [
+			{ id: null, name: "Root" },
+			{ id: 3, name: "Projects" },
+		];
+		mockState.store.currentFolderId = 3;
+		mockState.store.navigateTo.mockImplementationOnce(
+			async (folderId: number | null, folderName?: string) => {
+				try {
+					await realFileStore.getState().navigateTo(folderId, folderName);
+				} finally {
+					const state = realFileStore.getState();
+					mockState.store.error = state.error;
+					mockState.store.unavailableFolderId = state.unavailableFolderId;
+				}
+			},
+		);
+
+		const view = render(<FileBrowserPage />);
+
+		await waitFor(() => {
+			expect(realFileStore.getState().unavailableFolderId).toBe(12);
+		});
+		expect(mockState.store.unavailableFolderId).toBe(12);
+		view.rerender(<FileBrowserPage />);
+
+		await waitFor(() => {
+			expect(mockState.navigate).toHaveBeenCalledWith(
+				"/folder/3?name=Projects",
+				{ replace: true },
+			);
+		});
+		expect(mockState.toastError).toHaveBeenCalledWith(
+			"errors:folder_not_found",
+		);
+		expect(mockState.handleApiError).not.toHaveBeenCalled();
+	});
 
 	it.each([
 		[{ kind: "personal" } as const, "/"],

--- a/frontend-panel/src/pages/FileBrowserPage.tsx
+++ b/frontend-panel/src/pages/FileBrowserPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { useParams, useSearchParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import type { BatchTargetFolderSelection } from "@/components/files/BatchTargetFolderDialog";
 import { getImagePreviewNavigation } from "@/components/files/preview/navigation/imagePreviewNavigation";
@@ -17,7 +17,7 @@ import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { formatBatchToast } from "@/lib/formatBatchToast";
 import { runWhenIdle } from "@/lib/idleTask";
-import { workspaceKey } from "@/lib/workspace";
+import { workspaceFolderPath, workspaceKey } from "@/lib/workspace";
 import { FileBrowserDialogs } from "@/pages/file-browser/FileBrowserDialogs";
 import { FileBrowserToolbar } from "@/pages/file-browser/FileBrowserToolbar";
 import { FileBrowserWorkspace } from "@/pages/file-browser/FileBrowserWorkspace";
@@ -26,6 +26,7 @@ import {
 	FolderPolicyDialog as FolderPolicyDialogPreloader,
 	OfflineDownloadDialog as OfflineDownloadDialogPreloader,
 } from "@/pages/file-browser/fileBrowserLazy";
+import { resolveFolderRecoveryTarget } from "@/pages/file-browser/folderRecovery";
 import { useFileBrowserArchiveActions } from "@/pages/file-browser/useFileBrowserArchiveActions";
 import { useFileBrowserBatchActions } from "@/pages/file-browser/useFileBrowserBatchActions";
 import { useFileBrowserContextValue } from "@/pages/file-browser/useFileBrowserContextValue";
@@ -97,11 +98,11 @@ export default function FileBrowserPage() {
 	const { t } = useTranslation(["files", "tasks"]);
 	const params = useParams<{ folderId?: string }>();
 	const [searchParams] = useSearchParams();
+	const navigate = useNavigate();
 	const folderId = params.folderId ? Number(params.folderId) : null;
 	const folderName = searchParams.get("name") ?? undefined;
-	const currentWorkspaceKey = useWorkspaceStore((s) =>
-		workspaceKey(s.workspace),
-	);
+	const currentWorkspace = useWorkspaceStore((s) => s.workspace);
+	const currentWorkspaceKey = workspaceKey(currentWorkspace);
 	const navigationTarget = useMemo(
 		() => ({
 			folderId,
@@ -125,6 +126,7 @@ export default function FileBrowserPage() {
 	const browserOpenMode = useFileStore((s) => s.browserOpenMode);
 	const setViewMode = useFileStore((s) => s.setViewMode);
 	const error = useFileStore((s) => s.error);
+	const unavailableFolderId = useFileStore((s) => s.unavailableFolderId);
 	const clearSelection = useFileStore((s) => s.clearSelection);
 	const loadMoreFiles = useFileStore((s) => s.loadMoreFiles);
 	const loadingMore = useFileStore((s) => s.loadingMore);
@@ -154,6 +156,33 @@ export default function FileBrowserPage() {
 
 	usePageTitle(pageTitle);
 	useKeyboardShortcuts();
+
+	useEffect(() => {
+		if (unavailableFolderId === null || folderId !== unavailableFolderId) {
+			return;
+		}
+
+		const recoveryTarget = resolveFolderRecoveryTarget(
+			breadcrumb,
+			unavailableFolderId,
+		);
+		toast.error(t("errors:folder_not_found"));
+		navigate(
+			workspaceFolderPath(
+				currentWorkspace,
+				recoveryTarget.id,
+				recoveryTarget.id === null ? undefined : recoveryTarget.name,
+			),
+			{ replace: true },
+		);
+	}, [
+		breadcrumb,
+		currentWorkspace,
+		folderId,
+		navigate,
+		t,
+		unavailableFolderId,
+	]);
 
 	const uploadAreaRef = useRef<UploadAreaHandle | null>(null);
 	const uploadReadyRef = useRef(false);

--- a/frontend-panel/src/pages/TrashPage.test.tsx
+++ b/frontend-panel/src/pages/TrashPage.test.tsx
@@ -640,40 +640,43 @@ describe("TrashPage", () => {
 		});
 	});
 
-	it("reloads trash contents and quota when a sync.required event arrives", async () => {
-		mockState.list
-			.mockResolvedValueOnce({
-				files: [fileItem],
-				files_total: 1,
-				folders: [],
-				folders_total: 0,
-				next_file_cursor: null,
-			} as never)
-			.mockResolvedValueOnce(emptyTrashContents());
+	it.each(["sync.required", "trash.purged_all"] as const)(
+		"reloads trash contents and quota when a %s event arrives",
+		async (kind) => {
+			mockState.list
+				.mockResolvedValueOnce({
+					files: [fileItem],
+					files_total: 1,
+					folders: [],
+					folders_total: 0,
+					next_file_cursor: null,
+				} as never)
+				.mockResolvedValueOnce(emptyTrashContents());
 
-		render(<TrashPage />);
+			render(<TrashPage />);
 
-		await screen.findByText("select:report.pdf");
+			await screen.findByText("select:report.pdf");
 
-		for (const listener of mockState.listeners) {
-			listener({
-				kind: "sync.required",
-				workspace: { kind: "personal" },
-				file_ids: [],
-				folder_ids: [],
-				affected_parent_ids: [],
-				root_affected: false,
-				affects_quota: true,
-				storage_delta: null,
-				at: "2026-05-19T00:00:00Z",
+			for (const listener of mockState.listeners) {
+				listener({
+					kind,
+					workspace: { kind: "personal" },
+					file_ids: [],
+					folder_ids: [],
+					affected_parent_ids: [],
+					root_affected: false,
+					affects_quota: true,
+					storage_delta: null,
+					at: "2026-05-19T00:00:00Z",
+				});
+			}
+
+			await waitFor(() => {
+				expect(mockState.list).toHaveBeenCalledTimes(2);
 			});
-		}
-
-		await waitFor(() => {
-			expect(mockState.list).toHaveBeenCalledTimes(2);
-		});
-		expect(mockState.refreshUser).toHaveBeenCalledWith({ fields: ["quota"] });
-	});
+			expect(mockState.refreshUser).toHaveBeenCalledWith({ fields: ["quota"] });
+		},
+	);
 
 	it("ignores storage events that do not require a full sync", async () => {
 		mockState.list.mockResolvedValueOnce({

--- a/frontend-panel/src/pages/TrashPage.test.tsx
+++ b/frontend-panel/src/pages/TrashPage.test.tsx
@@ -762,6 +762,46 @@ describe("TrashPage", () => {
 		});
 	});
 
+	it("queues trash.purged_all received during an active reload", async () => {
+		let resolveReload:
+			| ((value: ReturnType<typeof emptyTrashContents>) => void)
+			| null = null;
+		mockState.list
+			.mockResolvedValueOnce({
+				files: [fileItem],
+				files_total: 1,
+				folders: [],
+				folders_total: 0,
+				next_file_cursor: null,
+			} as never)
+			.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveReload = resolve;
+					}) as never,
+			)
+			.mockResolvedValueOnce(emptyTrashContents());
+
+		render(<TrashPage />);
+		await screen.findByText("select:report.pdf");
+
+		for (const listener of mockState.listeners) {
+			listener({ kind: "sync.required" });
+			listener({ kind: "trash.purged_all" });
+			listener({ kind: "trash.purged_all" });
+		}
+
+		await waitFor(() => {
+			expect(mockState.list).toHaveBeenCalledTimes(2);
+		});
+		resolveReload?.(emptyTrashContents());
+
+		await waitFor(() => {
+			expect(mockState.list).toHaveBeenCalledTimes(3);
+		});
+		expect(mockState.refreshUser).toHaveBeenCalledTimes(2);
+	});
+
 	it("shows the server total even when only the first trash page is loaded", async () => {
 		mockState.list.mockResolvedValueOnce({
 			files: [fileItem],

--- a/frontend-panel/src/pages/TrashPage.tsx
+++ b/frontend-panel/src/pages/TrashPage.tsx
@@ -79,6 +79,7 @@ export default function TrashPage() {
 		usePendingAction();
 	const pendingRef = useRef(false);
 	const syncInFlightRef = useRef(false);
+	const purgeAllSyncPendingRef = useRef(false);
 	const sentinelRef = useRef<HTMLDivElement | null>(null);
 
 	// D9 Finder 化：回收站复用文件浏览器（trashMode），选择状态走 fileStore
@@ -195,20 +196,37 @@ export default function TrashPage() {
 	}, []);
 
 	useEffect(() => {
-		return subscribeStorageChange((event) => {
-			if (event.kind !== "sync.required" && event.kind !== "trash.purged_all") {
-				return;
-			}
-			if (syncInFlightRef.current) {
-				return;
-			}
+		let active = true;
+		const runSync = () => {
 			syncInFlightRef.current = true;
 			void Promise.all([load(), refreshUser({ fields: ["quota"] })]).finally(
 				() => {
 					syncInFlightRef.current = false;
+					if (!active || !purgeAllSyncPendingRef.current) {
+						return;
+					}
+					purgeAllSyncPendingRef.current = false;
+					runSync();
 				},
 			);
+		};
+		const unsubscribe = subscribeStorageChange((event) => {
+			if (event.kind !== "sync.required" && event.kind !== "trash.purged_all") {
+				return;
+			}
+			if (syncInFlightRef.current) {
+				if (event.kind === "trash.purged_all") {
+					purgeAllSyncPendingRef.current = true;
+				}
+				return;
+			}
+			runSync();
 		});
+		return () => {
+			active = false;
+			purgeAllSyncPendingRef.current = false;
+			unsubscribe();
+		};
 	}, [load, refreshUser]);
 
 	// Infinite scroll

--- a/frontend-panel/src/pages/TrashPage.tsx
+++ b/frontend-panel/src/pages/TrashPage.tsx
@@ -196,7 +196,7 @@ export default function TrashPage() {
 
 	useEffect(() => {
 		return subscribeStorageChange((event) => {
-			if (event.kind !== "sync.required") {
+			if (event.kind !== "sync.required" && event.kind !== "trash.purged_all") {
 				return;
 			}
 			if (syncInFlightRef.current) {

--- a/frontend-panel/src/pages/file-browser/folderRecovery.test.ts
+++ b/frontend-panel/src/pages/file-browser/folderRecovery.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "@/services/http";
+import { ApiErrorCode } from "@/types/api-helpers";
+import {
+	isFolderUnavailableError,
+	resolveFolderRecoveryTarget,
+} from "./folderRecovery";
+
+describe("folderRecovery", () => {
+	it("falls back to the parent before an unavailable current folder", () => {
+		expect(
+			resolveFolderRecoveryTarget(
+				[
+					{ id: null, name: "Root" },
+					{ id: 3, name: "Projects" },
+					{ id: 7, name: "Reports" },
+				],
+				7,
+			),
+		).toEqual({ id: 3, name: "Projects" });
+	});
+
+	it("uses the current folder as the parent of a failed child navigation", () => {
+		expect(
+			resolveFolderRecoveryTarget(
+				[
+					{ id: null, name: "Root" },
+					{ id: 3, name: "Projects" },
+				],
+				7,
+			),
+		).toEqual({ id: 3, name: "Projects" });
+	});
+
+	it("falls back to root when no valid breadcrumb candidate remains", () => {
+		expect(
+			resolveFolderRecoveryTarget([{ id: null, name: "Root" }], 7),
+		).toEqual({ id: null, name: "Root" });
+	});
+
+	it("ignores stale breadcrumb entries after the unavailable folder", () => {
+		expect(
+			resolveFolderRecoveryTarget(
+				[
+					{ id: null, name: "Root" },
+					{ id: 3, name: "Projects" },
+					{ id: 7, name: "Removed" },
+					{ id: 9, name: "Stale child" },
+				],
+				7,
+			),
+		).toEqual({ id: 3, name: "Projects" });
+	});
+
+	it("recognizes only the stable folder.not_found API code", () => {
+		expect(
+			isFolderUnavailableError(
+				new ApiError(ApiErrorCode.FolderNotFound, "Folder is gone"),
+			),
+		).toBe(true);
+		expect(
+			isFolderUnavailableError(
+				new ApiError(ApiErrorCode.NotFound, "Generic missing resource"),
+			),
+		).toBe(false);
+	});
+});

--- a/frontend-panel/src/pages/file-browser/folderRecovery.test.ts
+++ b/frontend-panel/src/pages/file-browser/folderRecovery.test.ts
@@ -38,6 +38,13 @@ describe("folderRecovery", () => {
 		).toEqual({ id: null, name: "Root" });
 	});
 
+	it("creates a root target when the breadcrumb is empty", () => {
+		expect(resolveFolderRecoveryTarget([], 7)).toEqual({
+			id: null,
+			name: "Root",
+		});
+	});
+
 	it("ignores stale breadcrumb entries after the unavailable folder", () => {
 		expect(
 			resolveFolderRecoveryTarget(

--- a/frontend-panel/src/pages/file-browser/folderRecovery.ts
+++ b/frontend-panel/src/pages/file-browser/folderRecovery.ts
@@ -1,0 +1,19 @@
+import { isApiErrorWithCode } from "@/services/http";
+import type { BreadcrumbItem } from "@/stores/fileStore";
+import { ApiErrorCode } from "@/types/api-helpers";
+
+export function isFolderUnavailableError(error: unknown) {
+	return isApiErrorWithCode(error, ApiErrorCode.FolderNotFound);
+}
+
+export function resolveFolderRecoveryTarget(
+	breadcrumb: BreadcrumbItem[],
+	unavailableFolderId: number,
+): BreadcrumbItem {
+	const unavailableIndex = breadcrumb.findIndex(
+		(item) => item.id === unavailableFolderId,
+	);
+	const candidates =
+		unavailableIndex >= 0 ? breadcrumb.slice(0, unavailableIndex) : breadcrumb;
+	return candidates.at(-1) ?? { id: null, name: "Root" };
+}

--- a/frontend-panel/src/pages/file-browser/useFileBrowserPageState.test.tsx
+++ b/frontend-panel/src/pages/file-browser/useFileBrowserPageState.test.tsx
@@ -2,14 +2,21 @@ import { act, renderHook } from "@testing-library/react";
 import type { TFunction } from "i18next";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "@/services/http";
 import type { FileListItem, FolderListItem } from "@/types/api";
+import { ApiErrorCode } from "@/types/api-helpers";
 import { useFileBrowserPageState } from "./useFileBrowserPageState";
 
 const mockState = vi.hoisted(() => ({
+	handleApiError: vi.fn(),
 	renamePreload: vi.fn(),
 	sharePreload: vi.fn(),
 	targetPreload: vi.fn(),
 	versionPreload: vi.fn(),
+}));
+
+vi.mock("@/hooks/useApiError", () => ({
+	handleApiError: (...args: unknown[]) => mockState.handleApiError(...args),
 }));
 
 vi.mock("@/pages/file-browser/fileBrowserLazy", () => ({
@@ -43,10 +50,34 @@ function wrapper({ children }: { children: React.ReactNode }) {
 
 describe("useFileBrowserPageState", () => {
 	beforeEach(() => {
+		mockState.handleApiError.mockReset();
 		mockState.renamePreload.mockReset();
 		mockState.sharePreload.mockReset();
 		mockState.targetPreload.mockReset();
 		mockState.versionPreload.mockReset();
+	});
+
+	it("suppresses folder-unavailable navigation errors", async () => {
+		const options = createOptions();
+		const error = new ApiError(ApiErrorCode.FolderNotFound, "gone");
+		options.navigateTo.mockRejectedValueOnce(error);
+
+		renderHook(() => useFileBrowserPageState(options), { wrapper });
+
+		await vi.waitFor(() => expect(options.navigateTo).toHaveBeenCalled());
+		expect(mockState.handleApiError).not.toHaveBeenCalled();
+	});
+
+	it("reports non-folder navigation errors", async () => {
+		const options = createOptions();
+		const error = new Error("network down");
+		options.navigateTo.mockRejectedValueOnce(error);
+
+		renderHook(() => useFileBrowserPageState(options), { wrapper });
+
+		await vi.waitFor(() => {
+			expect(mockState.handleApiError).toHaveBeenCalledWith(error);
+		});
 	});
 
 	it("opens an auto preview when image navigation arrives without current preview state", () => {

--- a/frontend-panel/src/pages/file-browser/useFileBrowserPageState.ts
+++ b/frontend-panel/src/pages/file-browser/useFileBrowserPageState.ts
@@ -32,6 +32,7 @@ import type {
 	FileListItem,
 	FolderListItem,
 } from "@/types/api";
+import { isFolderUnavailableError } from "./folderRecovery";
 
 const ENTITY_TYPE_BY_TARGET = {
 	file: "file",
@@ -98,7 +99,11 @@ export function useFileBrowserPageState({
 		setInfoPanelOpen(false);
 		setInfoTarget(null);
 		navigateTo(navigationTarget.folderId, navigationTarget.folderName).catch(
-			handleApiError,
+			(error) => {
+				if (!isFolderUnavailableError(error)) {
+					handleApiError(error);
+				}
+			},
 		);
 	}, [navigateTo, navigationTarget]);
 

--- a/frontend-panel/src/services/api.generated.ts
+++ b/frontend-panel/src/services/api.generated.ts
@@ -7897,7 +7897,7 @@ export interface components {
             workspace: null | components["schemas"]["StorageChangeWorkspace"];
         };
         /** @enum {string} */
-        StorageChangeKind: "file.created" | "file.updated" | "file.trashed" | "file.restored_from_trash" | "file.purged" | "file.version_restored" | "file.version_deleted" | "folder.created" | "folder.updated" | "folder.trashed" | "folder.restored_from_trash" | "folder.purged" | "tag.created" | "tag.updated" | "tag.deleted" | "tag.assignment_changed" | "lock.created" | "lock.deleted" | "sync.required";
+        StorageChangeKind: "file.created" | "file.updated" | "file.trashed" | "file.restored_from_trash" | "file.purged" | "file.version_restored" | "file.version_deleted" | "folder.created" | "folder.updated" | "folder.trashed" | "folder.restored_from_trash" | "folder.purged" | "tag.created" | "tag.updated" | "tag.deleted" | "tag.assignment_changed" | "lock.created" | "lock.deleted" | "trash.purged_all" | "sync.required";
         StorageChangeWorkspace: {
             /** @enum {string} */
             kind: "personal";

--- a/frontend-panel/src/services/http.ts
+++ b/frontend-panel/src/services/http.ts
@@ -237,6 +237,18 @@ export class ApiError extends Error {
 	}
 }
 
+export function isApiErrorWithCode(
+	error: unknown,
+	code: ApiErrorCode,
+): error is ApiError {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		error.code === code
+	);
+}
+
 export class ApiPendingError extends Error {
 	retryAfterSeconds: number;
 

--- a/frontend-panel/src/stores/fileStore.actions.test.ts
+++ b/frontend-panel/src/stores/fileStore.actions.test.ts
@@ -3,6 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { STORAGE_KEYS } from "@/config/app";
 import { FILE_PAGE_SIZE, FOLDER_LIMIT } from "@/lib/constants";
 import { ApiError } from "@/services/http";
+import {
+	beginWorkspaceRequest,
+	cancelWorkspaceRequest,
+	finishWorkspaceRequest,
+} from "@/stores/fileStore/request";
 import { createFolderContents } from "@/test/fixtures";
 import type { FolderContents } from "@/types/api";
 import { ApiErrorCode } from "@/types/api-helpers";
@@ -216,6 +221,66 @@ describe("useFileStore actions", () => {
 		expect(state.clipboard).toBeNull();
 	});
 
+	it("cancels a pending workspace request and clears its identity", async () => {
+		const { useFileStore } = await loadStore();
+		const controller = new AbortController();
+		useFileStore.setState({
+			_workspaceRequestController: controller,
+			_workspaceRequestIntent: "refresh",
+			_workspaceRequestFolderId: 5,
+			_workspaceRequestId: 4,
+		});
+
+		cancelWorkspaceRequest(useFileStore.setState, useFileStore.getState);
+
+		expect(controller.signal.aborted).toBe(true);
+		expect(useFileStore.getState()).toMatchObject({
+			_workspaceRequestController: null,
+			_workspaceRequestIntent: null,
+			_workspaceRequestFolderId: null,
+			_workspaceRequestId: 5,
+		});
+	});
+
+	it("leaves request state unchanged when there is nothing to cancel", async () => {
+		const { useFileStore } = await loadStore();
+		useFileStore.setState({ _workspaceRequestId: 4 });
+
+		cancelWorkspaceRequest(useFileStore.setState, useFileStore.getState);
+
+		expect(useFileStore.getState()._workspaceRequestId).toBe(4);
+	});
+
+	it("finishes the current request and rejects a repeated finish", async () => {
+		const { useFileStore } = await loadStore();
+		const request = beginWorkspaceRequest(
+			useFileStore.setState,
+			useFileStore.getState,
+			"navigation",
+			12,
+		);
+
+		expect(
+			finishWorkspaceRequest(
+				useFileStore.setState,
+				useFileStore.getState,
+				request,
+			),
+		).toBe(true);
+		expect(useFileStore.getState()).toMatchObject({
+			_workspaceRequestController: null,
+			_workspaceRequestIntent: null,
+			_workspaceRequestFolderId: null,
+		});
+		expect(
+			finishWorkspaceRequest(
+				useFileStore.setState,
+				useFileStore.getState,
+				request,
+			),
+		).toBe(false);
+	});
+
 	it("manages selection helpers across files and folders", async () => {
 		const { useFileStore } = await loadStore();
 		const contents = createFolderContents({
@@ -291,6 +356,74 @@ describe("useFileStore actions", () => {
 		expect(useFileStore.getState().files).toEqual([
 			expect.objectContaining({ id: 8, name: "zeta.txt" }),
 		]);
+	});
+
+	it("replays a sort refresh for the final folder after navigation", async () => {
+		const pending = deferred<FolderContents>();
+		mockState.listFolder
+			.mockImplementationOnce(() => pending.promise)
+			.mockResolvedValueOnce(
+				createFolderContents({
+					files: [{ id: 90, name: "sorted.txt" }],
+					files_total: 1,
+				}),
+			);
+		mockState.getFolderAncestors.mockResolvedValue([]);
+		const { useFileStore } = await loadStore();
+		useFileStore.setState({ currentFolderId: 5 });
+
+		const navigation = useFileStore.getState().navigateTo(12, "Projects");
+		useFileStore.getState().setSortOrder("desc");
+
+		expect(mockState.listFolder).toHaveBeenCalledTimes(1);
+		pending.resolve(createFolderContents());
+		await navigation;
+
+		expect(mockState.listFolder).toHaveBeenCalledTimes(2);
+		expectFolderRefresh(2, 12, "name", "desc");
+		expect(useFileStore.getState()).toMatchObject({
+			currentFolderId: 12,
+			sortOrder: "desc",
+		});
+		expect(useFileStore.getState().files).toEqual([
+			expect.objectContaining({ id: 90, name: "sorted.txt" }),
+		]);
+	});
+
+	it("logs a failed post-navigation sort refresh without failing navigation", async () => {
+		const pending = deferred<FolderContents>();
+		const refreshError = new Error("sort refresh failed");
+		mockState.listFolder
+			.mockImplementationOnce(() => pending.promise)
+			.mockRejectedValueOnce(refreshError);
+		mockState.getFolderAncestors.mockResolvedValue([]);
+		const { useFileStore } = await loadStore();
+		useFileStore.setState({ currentFolderId: 5 });
+
+		const navigation = useFileStore.getState().navigateTo(12, "Projects");
+		useFileStore.getState().setSortOrder("desc");
+		pending.resolve(createFolderContents());
+
+		await expect(navigation).resolves.toBeUndefined();
+		expect(mockState.warn).toHaveBeenCalledWith(
+			"post-navigation sort refresh failed",
+			refreshError,
+		);
+	});
+
+	it("records a generic navigation failure without a folder-unavailable marker", async () => {
+		const failure = "temporary failure";
+		mockState.listFolder.mockRejectedValue(failure);
+		const { useFileStore } = await loadStore();
+
+		await expect(
+			useFileStore.getState().navigateTo(12, "Projects"),
+		).rejects.toBe(failure);
+		expect(useFileStore.getState()).toMatchObject({
+			error: "Projects",
+			unavailableFolderId: null,
+			loading: false,
+		});
 	});
 
 	it("applies server preferences into state and local storage", async () => {
@@ -515,6 +648,24 @@ describe("useFileStore actions", () => {
 		]);
 	});
 
+	it("does not let load-more supersede route navigation", async () => {
+		const pending = deferred<FolderContents>();
+		mockState.listFolder.mockReturnValue(pending.promise);
+		mockState.getFolderAncestors.mockResolvedValue([]);
+		const { useFileStore } = await loadStore();
+		useFileStore.setState({
+			currentFolderId: 5,
+			nextFileCursor: { id: 10, value: "cursor" },
+		});
+
+		const navigation = useFileStore.getState().navigateTo(12, "Projects");
+		await useFileStore.getState().loadMoreFiles();
+
+		expect(mockState.listFolder).toHaveBeenCalledTimes(1);
+		pending.resolve(createFolderContents());
+		await navigation;
+	});
+
 	it("does not request a refresh for an expired folder snapshot", async () => {
 		const { useFileStore } = await loadStore();
 		useFileStore.setState({ currentFolderId: 12 });
@@ -563,6 +714,41 @@ describe("useFileStore actions", () => {
 		expect(useFileStore.getState().files).toEqual([
 			expect.objectContaining({ id: 90, name: "target.txt" }),
 		]);
+	});
+
+	it("finishes a refresh canceled by newer navigation", async () => {
+		mockState.listFolder.mockImplementation(
+			(
+				folderId: number,
+				_params: unknown,
+				options: { signal: AbortSignal },
+			) => {
+				if (folderId !== 5) {
+					return Promise.resolve(createFolderContents());
+				}
+				return new Promise((_resolve, reject) => {
+					options.signal.addEventListener(
+						"abort",
+						() =>
+							reject(
+								Object.assign(new Error("canceled"), {
+									code: "ERR_CANCELED",
+								}),
+							),
+						{ once: true },
+					);
+				});
+			},
+		);
+		mockState.getFolderAncestors.mockResolvedValue([]);
+		const { useFileStore } = await loadStore();
+		useFileStore.setState({ currentFolderId: 5 });
+
+		const refresh = useFileStore.getState().refresh(5);
+		await useFileStore.getState().navigateTo(12, "Projects");
+
+		await expect(refresh).resolves.toBeUndefined();
+		expect(useFileStore.getState().currentFolderId).toBe(12);
 	});
 
 	it("keeps navigation authoritative when a move completion refresh arrives late", async () => {
@@ -621,6 +807,39 @@ describe("useFileStore actions", () => {
 			error: "Folder #5 is in trash",
 			loading: false,
 			unavailableFolderId: 5,
+		});
+	});
+
+	it("marks a folder.not_found navigation as a recoverable unavailable route", async () => {
+		const notFound = new ApiError(
+			ApiErrorCode.FolderNotFound,
+			"Folder #12 is in trash",
+			{ retryable: false, status: 404 },
+		);
+		mockState.listFolder.mockRejectedValue(notFound);
+		const { useFileStore } = await loadStore();
+
+		await expect(
+			useFileStore.getState().navigateTo(12, "Projects"),
+		).rejects.toBe(notFound);
+		expect(useFileStore.getState()).toMatchObject({
+			error: "Folder #12 is in trash",
+			unavailableFolderId: 12,
+			loading: false,
+		});
+	});
+
+	it("uses the current folder and fallback message for an untyped refresh error", async () => {
+		const failure = "temporary failure";
+		mockState.listFolder.mockRejectedValue(failure);
+		const { useFileStore } = await loadStore();
+		useFileStore.setState({ currentFolderId: 5 });
+
+		await expect(useFileStore.getState().refresh()).rejects.toBe(failure);
+		expect(useFileStore.getState()).toMatchObject({
+			error: "Failed to refresh folder",
+			unavailableFolderId: null,
+			loading: false,
 		});
 	});
 });

--- a/frontend-panel/src/stores/fileStore.actions.test.ts
+++ b/frontend-panel/src/stores/fileStore.actions.test.ts
@@ -2,8 +2,18 @@ import { waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { STORAGE_KEYS } from "@/config/app";
 import { FILE_PAGE_SIZE, FOLDER_LIMIT } from "@/lib/constants";
+import { ApiError } from "@/services/http";
 import { createFolderContents } from "@/test/fixtures";
 import type { FolderContents } from "@/types/api";
+import { ApiErrorCode } from "@/types/api-helpers";
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((nextResolve) => {
+		resolve = nextResolve;
+	});
+	return { promise, resolve };
+}
 
 const mockState = vi.hoisted(() => ({
 	batchCopy: vi.fn(),
@@ -135,6 +145,7 @@ describe("useFileStore actions", () => {
 		mockState.deleteFile.mockReset();
 		mockState.deleteFolder.mockReset();
 		mockState.getFolderAncestors.mockReset();
+		mockState.getFolderAncestors.mockResolvedValue([]);
 		mockState.listFolder.mockReset();
 		mockState.listRoot.mockReset();
 		mockState.queuePreferenceSync.mockReset();
@@ -464,5 +475,152 @@ describe("useFileStore actions", () => {
 		expect(useFileStore.getState().loading).toBe(false);
 		expect(useFileStore.getState().loadingMore).toBe(false);
 		expect(useFileStore.getState().error).toBeNull();
+	});
+
+	it("does not let a current-folder refresh supersede route navigation", async () => {
+		const navigationContents = deferred<FolderContents>();
+		mockState.listFolder.mockImplementation((folderId: number) => {
+			if (folderId === 12) return navigationContents.promise;
+			return Promise.resolve(createFolderContents());
+		});
+		mockState.getFolderAncestors.mockResolvedValue([
+			{ id: 12, name: "Projects" },
+		]);
+
+		const { useFileStore } = await loadStore();
+		useFileStore.setState({ currentFolderId: 5 });
+
+		const navigation = useFileStore.getState().navigateTo(12, "Projects");
+		const navigationSignal = mockState.listFolder.mock.calls[0]?.[2]
+			?.signal as AbortSignal;
+		await useFileStore.getState().refresh(5);
+
+		expect(mockState.listFolder).toHaveBeenCalledTimes(1);
+		expect(navigationSignal.aborted).toBe(false);
+
+		navigationContents.resolve(
+			createFolderContents({
+				files: [{ id: 90, name: "target.txt" }],
+				files_total: 1,
+			}),
+		);
+		await navigation;
+
+		expect(useFileStore.getState()).toMatchObject({
+			currentFolderId: 12,
+			error: null,
+		});
+		expect(useFileStore.getState().files).toEqual([
+			expect.objectContaining({ id: 90, name: "target.txt" }),
+		]);
+	});
+
+	it("does not request a refresh for an expired folder snapshot", async () => {
+		const { useFileStore } = await loadStore();
+		useFileStore.setState({ currentFolderId: 12 });
+
+		await useFileStore.getState().refresh(5);
+
+		expect(mockState.listFolder).not.toHaveBeenCalled();
+		expect(mockState.listRoot).not.toHaveBeenCalled();
+		expect(mockState.getFolderAncestors).not.toHaveBeenCalled();
+		expect(useFileStore.getState().currentFolderId).toBe(12);
+	});
+
+	it("discards a stale refresh when newer navigation starts", async () => {
+		const oldContents = deferred<FolderContents>();
+		mockState.listFolder.mockImplementation((folderId: number) => {
+			if (folderId === 5) return oldContents.promise;
+			return Promise.resolve(
+				createFolderContents({
+					files: [{ id: 90, name: "target.txt" }],
+					files_total: 1,
+				}),
+			);
+		});
+		mockState.getFolderAncestors.mockImplementation((folderId: number) =>
+			Promise.resolve([{ id: folderId, name: `Folder ${folderId}` }]),
+		);
+
+		const { useFileStore } = await loadStore();
+		useFileStore.setState({ currentFolderId: 5 });
+
+		const refresh = useFileStore.getState().refresh(5);
+		const refreshSignal = mockState.listFolder.mock.calls[0]?.[2]
+			?.signal as AbortSignal;
+		await useFileStore.getState().navigateTo(12, "Projects");
+
+		expect(refreshSignal.aborted).toBe(true);
+		oldContents.resolve(
+			createFolderContents({
+				files: [{ id: 50, name: "stale.txt" }],
+				files_total: 1,
+			}),
+		);
+		await refresh;
+
+		expect(useFileStore.getState().currentFolderId).toBe(12);
+		expect(useFileStore.getState().files).toEqual([
+			expect.objectContaining({ id: 90, name: "target.txt" }),
+		]);
+	});
+
+	it("keeps navigation authoritative when a move completion refresh arrives late", async () => {
+		const moveResult = {
+			errors: [],
+			failed: 0,
+			succeeded: 1,
+		};
+		const pendingMove = deferred<typeof moveResult>();
+		mockState.batchMove.mockReturnValue(pendingMove.promise);
+		mockState.listFolder.mockResolvedValue(
+			createFolderContents({
+				files: [{ id: 90, name: "target.txt" }],
+				files_total: 1,
+			}),
+		);
+		mockState.getFolderAncestors.mockResolvedValue([
+			{ id: 12, name: "Projects" },
+		]);
+
+		const { useFileStore } = await loadStore();
+		useFileStore.setState({ currentFolderId: 5 });
+
+		const move = useFileStore.getState().moveToFolder([1], [], 9);
+		await useFileStore.getState().navigateTo(12, "Projects");
+		pendingMove.resolve(moveResult);
+		await move;
+
+		expect(mockState.listFolder).toHaveBeenCalledTimes(1);
+		expect(mockState.listFolder).toHaveBeenCalledWith(
+			12,
+			expect.any(Object),
+			expect.any(Object),
+		);
+		expect(useFileStore.getState().currentFolderId).toBe(12);
+		expect(useFileStore.getState().files).toEqual([
+			expect.objectContaining({ id: 90, name: "target.txt" }),
+		]);
+	});
+
+	it("marks a folder.not_found refresh as a recoverable unavailable route", async () => {
+		const notFound = new ApiError(
+			ApiErrorCode.FolderNotFound,
+			"Folder #5 is in trash",
+			{ retryable: false, status: 404 },
+		);
+		mockState.listFolder.mockRejectedValue(notFound);
+
+		const { useFileStore } = await loadStore();
+		useFileStore.setState({ currentFolderId: 5 });
+
+		await expect(useFileStore.getState().refresh(5)).rejects.toBe(notFound);
+
+		expect(useFileStore.getState()).toMatchObject({
+			currentFolderId: 5,
+			error: "Folder #5 is in trash",
+			loading: false,
+			unavailableFolderId: 5,
+		});
 	});
 });

--- a/frontend-panel/src/stores/fileStore/clipboardSlice.test.ts
+++ b/frontend-panel/src/stores/fileStore/clipboardSlice.test.ts
@@ -8,7 +8,7 @@ const mockState = vi.hoisted(() => ({
 	copyFolder: vi.fn(),
 	moveFile: vi.fn(),
 	moveFolder: vi.fn(),
-	fetchFolder: vi.fn(),
+	refresh: vi.fn(),
 }));
 
 vi.mock("@/services/batchService", () => ({
@@ -29,19 +29,12 @@ vi.mock("@/services/fileService", () => ({
 	},
 }));
 
-vi.mock("@/stores/fileStore/request", () => ({
-	applyWorkspaceRequestState: vi.fn(),
-	beginWorkspaceRequest: () => ({ signal: undefined }),
-	fetchFolder: (...args: unknown[]) => mockState.fetchFolder(...args),
-	getInitialPageParams: () => ({}),
-	isRequestCanceled: () => false,
-}));
-
 function createClipboardState(clipboard: unknown) {
 	let state: Record<string, unknown> = {
 		clipboard,
 		clearSelection: vi.fn(),
 		currentFolderId: 9,
+		refresh: mockState.refresh,
 		workspaceRequestRevision: 1,
 		sortBy: "name",
 		sortOrder: "asc",
@@ -70,13 +63,7 @@ describe("clipboard copy and move dispatch", () => {
 		mockState.copyFolder.mockReset().mockResolvedValue({ id: 2 });
 		mockState.moveFile.mockReset().mockResolvedValue({ id: 1 });
 		mockState.moveFolder.mockReset().mockResolvedValue({ id: 2 });
-		mockState.fetchFolder.mockReset().mockResolvedValue({
-			files: [],
-			folders: [],
-			files_total: 0,
-			folders_total: 0,
-			next_file_cursor: null,
-		});
+		mockState.refresh.mockReset().mockResolvedValue(undefined);
 	});
 
 	it("uses the single-file copy endpoint for one copied file", async () => {
@@ -90,6 +77,7 @@ describe("clipboard copy and move dispatch", () => {
 
 		expect(mockState.copyFile).toHaveBeenCalledWith(1, 9);
 		expect(mockState.batchCopy).not.toHaveBeenCalled();
+		expect(mockState.refresh).toHaveBeenCalledWith(9);
 	});
 
 	it("uses the single-folder copy endpoint for one copied folder", async () => {
@@ -103,6 +91,7 @@ describe("clipboard copy and move dispatch", () => {
 
 		expect(mockState.copyFolder).toHaveBeenCalledWith(2, 9);
 		expect(mockState.batchCopy).not.toHaveBeenCalled();
+		expect(mockState.refresh).toHaveBeenCalledWith(9);
 	});
 
 	it("uses batch copy for multiple copied resources", async () => {
@@ -116,6 +105,7 @@ describe("clipboard copy and move dispatch", () => {
 
 		expect(mockState.batchCopy).toHaveBeenCalledWith([1, 2], [], 9);
 		expect(mockState.copyFile).not.toHaveBeenCalled();
+		expect(mockState.refresh).toHaveBeenCalledWith(9);
 	});
 
 	it("uses the single-file move endpoint for one cut file", async () => {
@@ -130,6 +120,7 @@ describe("clipboard copy and move dispatch", () => {
 		expect(mockState.moveFile).toHaveBeenCalledWith(1, 9);
 		expect(mockState.batchMove).not.toHaveBeenCalled();
 		expect(mockState.copyFile).not.toHaveBeenCalled();
+		expect(mockState.refresh).toHaveBeenCalledWith(9);
 	});
 
 	it("uses the single-folder move endpoint for one cut folder", async () => {
@@ -144,6 +135,7 @@ describe("clipboard copy and move dispatch", () => {
 		expect(mockState.moveFolder).toHaveBeenCalledWith(2, 9);
 		expect(mockState.batchMove).not.toHaveBeenCalled();
 		expect(mockState.moveFile).not.toHaveBeenCalled();
+		expect(mockState.refresh).toHaveBeenCalledWith(9);
 	});
 
 	it("uses batch move for multiple cut resources", async () => {
@@ -158,5 +150,6 @@ describe("clipboard copy and move dispatch", () => {
 		expect(mockState.batchMove).toHaveBeenCalledWith([1], [2], 9);
 		expect(mockState.moveFile).not.toHaveBeenCalled();
 		expect(mockState.moveFolder).not.toHaveBeenCalled();
+		expect(mockState.refresh).toHaveBeenCalledWith(9);
 	});
 });

--- a/frontend-panel/src/stores/fileStore/clipboardSlice.ts
+++ b/frontend-panel/src/stores/fileStore/clipboardSlice.ts
@@ -1,13 +1,6 @@
 import { batchService, singleOperationResult } from "@/services/batchService";
 import { fileService } from "@/services/fileService";
 import type { BatchResult } from "@/types/api";
-import {
-	applyWorkspaceRequestState,
-	beginWorkspaceRequest,
-	fetchFolder,
-	getInitialPageParams,
-	isRequestCanceled,
-} from "./request";
 import type { ClipboardSlice, FileStoreSlice } from "./types";
 
 export const createClipboardSlice: FileStoreSlice<ClipboardSlice> = (
@@ -93,33 +86,7 @@ export const createClipboardSlice: FileStoreSlice<ClipboardSlice> = (
 			return { mode, result };
 		}
 
-		const request = beginWorkspaceRequest(set, get);
-
-		try {
-			const contents = await fetchFolder(
-				currentFolderId,
-				getInitialPageParams(get().sortBy, get().sortOrder),
-				request.signal,
-			);
-
-			applyWorkspaceRequestState(set, get, request, {
-				folders: contents.folders,
-				files: contents.files,
-				foldersTotalCount: contents.folders_total,
-				filesTotalCount: contents.files_total,
-				nextFileCursor: contents.next_file_cursor ?? null,
-				loading: false,
-				loadingMore: false,
-			});
-		} catch (error) {
-			if (!isRequestCanceled(error)) {
-				applyWorkspaceRequestState(set, get, request, {
-					loading: false,
-					loadingMore: false,
-				});
-				throw error;
-			}
-		}
+		await get().refresh(currentFolderId);
 
 		return { mode, result };
 	},

--- a/frontend-panel/src/stores/fileStore/crudSlice.ts
+++ b/frontend-panel/src/stores/fileStore/crudSlice.ts
@@ -6,30 +6,23 @@ import {
 } from "@/services/batchService";
 import { fileService } from "@/services/fileService";
 import { useWorkspaceStore } from "@/stores/workspaceStore";
-import {
-	applyWorkspaceRequestState,
-	beginWorkspaceRequest,
-	fetchFolder,
-	getInitialPageParams,
-	isRequestCanceled,
-	resolveBreadcrumb,
-} from "./request";
 import type { CrudSlice, FileStoreSlice } from "./types";
 
 export const createCrudSlice: FileStoreSlice<CrudSlice> = (set, get) => ({
 	createFile: async (name) => {
 		const { currentFolderId } = get();
 		await fileService.createEmptyFile(name, currentFolderId);
-		await get().refresh();
+		await get().refresh(currentFolderId);
 	},
 
 	createFolder: async (name) => {
 		const { currentFolderId } = get();
 		await fileService.createFolder(name, currentFolderId);
-		await get().refresh();
+		await get().refresh(currentFolderId);
 	},
 
 	deleteFile: async (id) => {
+		const { currentFolderId } = get();
 		const mutation = beginLocalStorageDeleteMutation({
 			workspace: useWorkspaceStore.getState().workspace,
 			fileIds: [id],
@@ -43,10 +36,11 @@ export const createCrudSlice: FileStoreSlice<CrudSlice> = (set, get) => ({
 		const next = new Set(get().selectedFileIds);
 		next.delete(id);
 		set({ selectedFileIds: next });
-		await get().refresh();
+		await get().refresh(currentFolderId);
 	},
 
 	deleteFolder: async (id) => {
+		const { currentFolderId } = get();
 		const mutation = beginLocalStorageDeleteMutation({
 			workspace: useWorkspaceStore.getState().workspace,
 			folderIds: [id],
@@ -60,11 +54,12 @@ export const createCrudSlice: FileStoreSlice<CrudSlice> = (set, get) => ({
 		const next = new Set(get().selectedFolderIds);
 		next.delete(id);
 		set({ selectedFolderIds: next });
-		await get().refresh();
+		await get().refresh(currentFolderId);
 	},
 
 	moveToFolder: async (fileIds, folderIds, targetFolderId) => {
 		const revision = get().workspaceRequestRevision;
+		const sourceFolderId = get().currentFolderId;
 		const workspace = useWorkspaceStore.getState().workspace;
 		const result = await resolveMoveDispatch({
 			currentWorkspace: workspace,
@@ -87,39 +82,7 @@ export const createCrudSlice: FileStoreSlice<CrudSlice> = (set, get) => ({
 			return result;
 		}
 
-		const { currentFolderId } = get();
-		const request = beginWorkspaceRequest(set, get);
-
-		try {
-			const [contents, breadcrumb] = await Promise.all([
-				fetchFolder(
-					currentFolderId,
-					getInitialPageParams(get().sortBy, get().sortOrder),
-					request.signal,
-				),
-				resolveBreadcrumb(currentFolderId, undefined, request.signal),
-			]);
-
-			applyWorkspaceRequestState(set, get, request, {
-				folders: contents.folders,
-				files: contents.files,
-				foldersTotalCount: contents.folders_total,
-				filesTotalCount: contents.files_total,
-				nextFileCursor: contents.next_file_cursor ?? null,
-				breadcrumb,
-				loading: false,
-				loadingMore: false,
-				error: null,
-			});
-		} catch (error) {
-			if (!isRequestCanceled(error)) {
-				applyWorkspaceRequestState(set, get, request, {
-					loading: false,
-					loadingMore: false,
-				});
-				throw error;
-			}
-		}
+		await get().refresh(sourceFolderId);
 
 		return result;
 	},

--- a/frontend-panel/src/stores/fileStore/navigationSlice.ts
+++ b/frontend-panel/src/stores/fileStore/navigationSlice.ts
@@ -35,8 +35,9 @@ export const createNavigationSlice: FileStoreSlice<NavigationSlice> = (
 	nextFileCursor: null,
 
 	navigateTo: async (folderId, folderName, breadcrumbPath) => {
+		const requestSortBy = get().sortBy;
+		const requestSortOrder = get().sortOrder;
 		const request = beginWorkspaceRequest(set, get, "navigation", folderId);
-		if (!request) return;
 		set({
 			loading: true,
 			error: null,
@@ -49,13 +50,13 @@ export const createNavigationSlice: FileStoreSlice<NavigationSlice> = (
 			const [contents, newBreadcrumb] = await Promise.all([
 				fetchFolder(
 					folderId,
-					getInitialPageParams(get().sortBy, get().sortOrder),
+					getInitialPageParams(requestSortBy, requestSortOrder),
 					request.signal,
 				),
 				resolveBreadcrumb(folderId, breadcrumbPath, request.signal),
 			]);
 
-			applyWorkspaceRequestState(set, get, request, {
+			const committed = applyWorkspaceRequestState(set, get, request, {
 				currentFolderId: folderId,
 				folders: contents.folders,
 				files: contents.files,
@@ -66,13 +67,24 @@ export const createNavigationSlice: FileStoreSlice<NavigationSlice> = (
 				lastFolderContents: {
 					folderId,
 					folders: contents.folders,
-					sortBy: get().sortBy,
-					sortOrder: get().sortOrder,
+					sortBy: requestSortBy,
+					sortOrder: requestSortOrder,
 					workspaceRevision: get().workspaceRequestRevision,
 				},
 				loading: false,
 				error: null,
 			});
+
+			if (
+				committed &&
+				(get().sortBy !== requestSortBy || get().sortOrder !== requestSortOrder)
+			) {
+				try {
+					await get().refresh(folderId);
+				} catch (error) {
+					logger.warn("post-navigation sort refresh failed", error);
+				}
+			}
 		} catch (error) {
 			if (isRequestCanceled(error)) {
 				finishWorkspaceRequest(set, get, request);

--- a/frontend-panel/src/stores/fileStore/navigationSlice.ts
+++ b/frontend-panel/src/stores/fileStore/navigationSlice.ts
@@ -1,5 +1,7 @@
 import { FILE_PAGE_SIZE } from "@/lib/constants";
 import { logger } from "@/lib/logger";
+import { isApiErrorWithCode } from "@/services/http";
+import { ApiErrorCode } from "@/types/api-helpers";
 import {
 	applyWorkspaceRequestState,
 	beginWorkspaceRequest,
@@ -26,16 +28,19 @@ export const createNavigationSlice: FileStoreSlice<NavigationSlice> = (
 	files: [],
 	loading: false,
 	error: null,
+	unavailableFolderId: null,
 	filesTotalCount: 0,
 	foldersTotalCount: 0,
 	loadingMore: false,
 	nextFileCursor: null,
 
 	navigateTo: async (folderId, folderName, breadcrumbPath) => {
-		const request = beginWorkspaceRequest(set, get);
+		const request = beginWorkspaceRequest(set, get, "navigation", folderId);
+		if (!request) return;
 		set({
 			loading: true,
 			error: null,
+			unavailableFolderId: null,
 			...createSelectionReset(),
 			...createWorkspaceContentReset(),
 		});
@@ -82,25 +87,39 @@ export const createNavigationSlice: FileStoreSlice<NavigationSlice> = (
 			applyWorkspaceRequestState(set, get, request, {
 				loading: false,
 				error: message,
+				unavailableFolderId: isApiErrorWithCode(
+					error,
+					ApiErrorCode.FolderNotFound,
+				)
+					? folderId
+					: null,
 			});
 			throw error;
 		}
 	},
 
-	refresh: async () => {
-		const { currentFolderId } = get();
-		const request = beginWorkspaceRequest(set, get);
+	refresh: async (folderIdSnapshot) => {
+		const currentFolderId =
+			folderIdSnapshot === undefined ? get().currentFolderId : folderIdSnapshot;
+		if (get().currentFolderId !== currentFolderId) return;
+		const request = beginWorkspaceRequest(set, get, "refresh", currentFolderId);
+		if (!request) return;
 		set({
 			loading: true,
+			error: null,
+			unavailableFolderId: null,
 			...createWorkspaceContentReset(),
 		});
 
 		try {
-			const contents = await fetchFolder(
-				currentFolderId,
-				getInitialPageParams(get().sortBy, get().sortOrder),
-				request.signal,
-			);
+			const [contents, breadcrumb] = await Promise.all([
+				fetchFolder(
+					currentFolderId,
+					getInitialPageParams(get().sortBy, get().sortOrder),
+					request.signal,
+				),
+				resolveBreadcrumb(currentFolderId, undefined, request.signal),
+			]);
 
 			applyWorkspaceRequestState(set, get, request, {
 				folders: contents.folders,
@@ -108,6 +127,7 @@ export const createNavigationSlice: FileStoreSlice<NavigationSlice> = (
 				foldersTotalCount: contents.folders_total,
 				filesTotalCount: contents.files_total,
 				nextFileCursor: contents.next_file_cursor ?? null,
+				breadcrumb,
 				lastFolderContents: {
 					folderId: currentFolderId,
 					folders: contents.folders,
@@ -116,6 +136,7 @@ export const createNavigationSlice: FileStoreSlice<NavigationSlice> = (
 					workspaceRevision: get().workspaceRequestRevision,
 				},
 				loading: false,
+				error: null,
 			});
 		} catch (error) {
 			if (isRequestCanceled(error)) {
@@ -123,7 +144,17 @@ export const createNavigationSlice: FileStoreSlice<NavigationSlice> = (
 				return;
 			}
 
-			applyWorkspaceRequestState(set, get, request, { loading: false });
+			applyWorkspaceRequestState(set, get, request, {
+				loading: false,
+				error:
+					error instanceof Error ? error.message : "Failed to refresh folder",
+				unavailableFolderId: isApiErrorWithCode(
+					error,
+					ApiErrorCode.FolderNotFound,
+				)
+					? currentFolderId
+					: null,
+			});
 			throw error;
 		}
 	},
@@ -133,7 +164,8 @@ export const createNavigationSlice: FileStoreSlice<NavigationSlice> = (
 			get();
 		if (loadingMore || !nextFileCursor) return;
 
-		const request = beginWorkspaceRequest(set, get);
+		const request = beginWorkspaceRequest(set, get, "refresh", currentFolderId);
+		if (!request) return;
 		set({ loadingMore: true });
 
 		try {

--- a/frontend-panel/src/stores/fileStore/preferencesSlice.ts
+++ b/frontend-panel/src/stores/fileStore/preferencesSlice.ts
@@ -32,10 +32,12 @@ function reloadSortedFolder(
 	sortBy: SortBy,
 	sortOrder: SortOrder,
 ) {
-	const request = beginWorkspaceRequest(set, get);
+	const currentFolderId = get().currentFolderId;
+	const request = beginWorkspaceRequest(set, get, "refresh", currentFolderId);
+	if (!request) return;
 
 	void fetchFolder(
-		get().currentFolderId,
+		currentFolderId,
 		getInitialPageParams(sortBy, sortOrder),
 		request.signal,
 	)

--- a/frontend-panel/src/stores/fileStore/request.ts
+++ b/frontend-panel/src/stores/fileStore/request.ts
@@ -14,6 +14,8 @@ import type {
 import { createRootBreadcrumb } from "./types";
 
 interface WorkspaceRequestHandle {
+	folderId: number | null;
+	intent: "navigation" | "refresh";
 	requestId: number;
 	revision: number;
 	signal: AbortSignal;
@@ -76,7 +78,13 @@ export async function resolveBreadcrumb(
 export function beginWorkspaceRequest(
 	set: FileStoreSet,
 	get: FileStoreGet,
-): WorkspaceRequestHandle {
+	intent: WorkspaceRequestHandle["intent"],
+	folderId: number | null,
+): WorkspaceRequestHandle | null {
+	if (intent === "refresh" && get()._workspaceRequestIntent === "navigation") {
+		return null;
+	}
+
 	get()._workspaceRequestController?.abort();
 
 	const requestId = get()._workspaceRequestId + 1;
@@ -84,9 +92,13 @@ export function beginWorkspaceRequest(
 	set({
 		_workspaceRequestId: requestId,
 		_workspaceRequestController: controller,
+		_workspaceRequestIntent: intent,
+		_workspaceRequestFolderId: folderId,
 	});
 
 	return {
+		folderId,
+		intent,
 		requestId,
 		revision: get().workspaceRequestRevision,
 		signal: controller.signal,
@@ -102,6 +114,8 @@ export function cancelWorkspaceRequest(set: FileStoreSet, get: FileStoreGet) {
 	controller.abort();
 	set((state) => ({
 		_workspaceRequestController: null,
+		_workspaceRequestIntent: null,
+		_workspaceRequestFolderId: null,
 		_workspaceRequestId: state._workspaceRequestId + 1,
 	}));
 }
@@ -113,7 +127,11 @@ export function isCurrentWorkspaceRequest(
 	const state = get();
 	return (
 		state.workspaceRequestRevision === request.revision &&
-		state._workspaceRequestId === request.requestId
+		state._workspaceRequestId === request.requestId &&
+		state._workspaceRequestIntent === request.intent &&
+		state._workspaceRequestFolderId === request.folderId &&
+		(request.intent === "navigation" ||
+			state.currentFolderId === request.folderId)
 	);
 }
 
@@ -126,7 +144,11 @@ export function finishWorkspaceRequest(
 		return false;
 	}
 
-	set({ _workspaceRequestController: null });
+	set({
+		_workspaceRequestController: null,
+		_workspaceRequestIntent: null,
+		_workspaceRequestFolderId: null,
+	});
 	return true;
 }
 
@@ -144,6 +166,8 @@ export function applyWorkspaceRequestState(
 		set((current) => ({
 			...state(current),
 			_workspaceRequestController: null,
+			_workspaceRequestIntent: null,
+			_workspaceRequestFolderId: null,
 		}));
 		return true;
 	}
@@ -151,6 +175,8 @@ export function applyWorkspaceRequestState(
 	set({
 		...state,
 		_workspaceRequestController: null,
+		_workspaceRequestIntent: null,
+		_workspaceRequestFolderId: null,
 	});
 	return true;
 }

--- a/frontend-panel/src/stores/fileStore/request.ts
+++ b/frontend-panel/src/stores/fileStore/request.ts
@@ -78,6 +78,18 @@ export async function resolveBreadcrumb(
 export function beginWorkspaceRequest(
 	set: FileStoreSet,
 	get: FileStoreGet,
+	intent: "navigation",
+	folderId: number | null,
+): WorkspaceRequestHandle;
+export function beginWorkspaceRequest(
+	set: FileStoreSet,
+	get: FileStoreGet,
+	intent: "refresh",
+	folderId: number | null,
+): WorkspaceRequestHandle | null;
+export function beginWorkspaceRequest(
+	set: FileStoreSet,
+	get: FileStoreGet,
 	intent: WorkspaceRequestHandle["intent"],
 	folderId: number | null,
 ): WorkspaceRequestHandle | null {

--- a/frontend-panel/src/stores/fileStore/requestSlice.ts
+++ b/frontend-panel/src/stores/fileStore/requestSlice.ts
@@ -9,6 +9,8 @@ export const createRequestSlice: FileStoreSlice<RequestSlice> = (set, get) => ({
 			lastFolderContents: null,
 			_workspaceRequestId: 0,
 			_workspaceRequestController: null,
+			_workspaceRequestIntent: null,
+			_workspaceRequestFolderId: null,
 			...createWorkspaceResetState(),
 		}));
 	},
@@ -16,4 +18,6 @@ export const createRequestSlice: FileStoreSlice<RequestSlice> = (set, get) => ({
 	workspaceRequestRevision: 0,
 	_workspaceRequestId: 0,
 	_workspaceRequestController: null,
+	_workspaceRequestIntent: null,
+	_workspaceRequestFolderId: null,
 });

--- a/frontend-panel/src/stores/fileStore/types.ts
+++ b/frontend-panel/src/stores/fileStore/types.ts
@@ -94,6 +94,8 @@ export interface RequestSlice {
 	workspaceRequestRevision: number;
 	_workspaceRequestId: number;
 	_workspaceRequestController: AbortController | null;
+	_workspaceRequestIntent: "navigation" | "refresh" | null;
+	_workspaceRequestFolderId: number | null;
 }
 
 export interface NavigationSlice {
@@ -103,6 +105,7 @@ export interface NavigationSlice {
 	files: FileListItem[];
 	loading: boolean;
 	error: string | null;
+	unavailableFolderId: number | null;
 	filesTotalCount: number;
 	foldersTotalCount: number;
 	loadingMore: boolean;
@@ -112,7 +115,7 @@ export interface NavigationSlice {
 		folderName?: string,
 		breadcrumbPath?: BreadcrumbItem[],
 	) => Promise<void>;
-	refresh: () => Promise<void>;
+	refresh: (folderIdSnapshot?: number | null) => Promise<void>;
 	loadMoreFiles: () => Promise<void>;
 	hasMoreFiles: () => boolean;
 }
@@ -221,6 +224,7 @@ export function createWorkspaceResetState() {
 		breadcrumb: createRootBreadcrumb(),
 		loading: false,
 		error: null as string | null,
+		unavailableFolderId: null as number | null,
 		clipboard: null as Clipboard | null,
 		...createWorkspaceContentReset(),
 		...createSelectionReset(),

--- a/src/services/events/storage_change.rs
+++ b/src/services/events/storage_change.rs
@@ -85,6 +85,8 @@ pub enum StorageChangeKind {
     LockCreated,
     #[serde(rename = "lock.deleted")]
     LockDeleted,
+    #[serde(rename = "trash.purged_all")]
+    TrashPurgedAll,
     #[serde(rename = "sync.required")]
     SyncRequired,
 }
@@ -108,7 +110,7 @@ impl StorageChangeKind {
             Self::TagCreated | Self::TagUpdated | Self::TagDeleted | Self::TagAssignmentChanged => {
                 false
             }
-            Self::LockCreated | Self::LockDeleted => false,
+            Self::LockCreated | Self::LockDeleted | Self::TrashPurgedAll => false,
         }
     }
 
@@ -132,7 +134,8 @@ impl StorageChangeKind {
             | Self::TagDeleted
             | Self::TagAssignmentChanged
             | Self::LockCreated
-            | Self::LockDeleted => false,
+            | Self::LockDeleted
+            | Self::TrashPurgedAll => false,
         }
     }
 }
@@ -569,6 +572,28 @@ mod tests {
                 crate::services::files::folder::FOLDER_PATH_CACHE_PREFIX.to_string(),
             ]
         );
+        assert!(targets.keys.is_empty());
+    }
+
+    #[test]
+    fn trash_purged_all_keeps_scoped_wire_kind_without_path_cache_invalidation() {
+        let event = StorageChangeEvent::new(
+            StorageChangeKind::TrashPurgedAll,
+            WorkspaceStorageScope::Personal { user_id: 11 },
+            vec![],
+            vec![],
+            vec![],
+        )
+        .with_storage_delta(-512);
+
+        let serialized = serde_json::to_value(&event).unwrap();
+        assert_eq!(serialized["kind"], "trash.purged_all");
+        assert_eq!(serialized["workspace"]["kind"], "personal");
+        assert_eq!(serialized["storage_delta"], -512);
+        assert_eq!(serialized["affects_quota"], true);
+
+        let targets = super::cache_invalidation_targets(&event);
+        assert!(targets.prefixes.is_empty());
         assert!(targets.keys.is_empty());
     }
 

--- a/src/services/events/storage_change.rs
+++ b/src/services/events/storage_change.rs
@@ -591,6 +591,8 @@ mod tests {
         assert_eq!(serialized["workspace"]["kind"], "personal");
         assert_eq!(serialized["storage_delta"], -512);
         assert_eq!(serialized["affects_quota"], true);
+        assert!(!event.kind.invalidates_folder_path_cache());
+        assert!(!event.kind.invalidates_webdav_path_cache());
 
         let targets = super::cache_invalidation_targets(&event);
         assert!(targets.prefixes.is_empty());

--- a/src/services/files/trash/purge.rs
+++ b/src/services/files/trash/purge.rs
@@ -208,7 +208,7 @@ pub(crate) fn publish_purge_all_storage_change(
     storage_change::publish(
         state,
         storage_change::StorageChangeEvent::new(
-            storage_change::StorageChangeKind::SyncRequired,
+            storage_change::StorageChangeKind::TrashPurgedAll,
             scope,
             vec![],
             vec![],

--- a/src/services/workspace/scope/mod.rs
+++ b/src/services/workspace/scope/mod.rs
@@ -331,8 +331,8 @@ pub(crate) fn ensure_active_folder_scope(
     ensure_folder_scope(folder, scope)?;
 
     if folder.deleted_at.is_some() {
-        return Err(AsterError::file_not_found(format!(
-            "folder #{} is in trash",
+        return Err(AsterError::folder_not_found(format!(
+            "Folder #{} is in trash",
             folder.id
         )));
     }
@@ -435,7 +435,14 @@ async fn verify_folder_access_with_db<C: ConnectionTrait>(
     // 先校验当前 scope 还有效，再取实体做归属检查。
     // 这样所有调用方都能拿到“存在 + 属于当前空间 + 未进回收站”的 folder。
     require_scope_access_with_db(state, db, scope).await?;
-    let folder = folder_repo::find_by_id(db, folder_id).await?;
+    let folder = folder_repo::find_by_id(db, folder_id)
+        .await
+        .map_err(|error| match error {
+            AsterError::RecordNotFound(_) => AsterError::folder_not_found(format!(
+                "Folder #{folder_id} does not exist or has been permanently removed"
+            )),
+            other => other,
+        })?;
     ensure_active_folder_scope(&folder, scope)?;
 
     Ok(folder)

--- a/src/services/workspace/scope/mod.rs
+++ b/src/services/workspace/scope/mod.rs
@@ -437,15 +437,19 @@ async fn verify_folder_access_with_db<C: ConnectionTrait>(
     require_scope_access_with_db(state, db, scope).await?;
     let folder = folder_repo::find_by_id(db, folder_id)
         .await
-        .map_err(|error| match error {
-            AsterError::RecordNotFound(_) => AsterError::folder_not_found(format!(
-                "Folder #{folder_id} does not exist or has been permanently removed"
-            )),
-            other => other,
-        })?;
+        .map_err(|error| map_folder_lookup_error(folder_id, error))?;
     ensure_active_folder_scope(&folder, scope)?;
 
     Ok(folder)
+}
+
+fn map_folder_lookup_error(folder_id: i64, error: AsterError) -> AsterError {
+    match error {
+        AsterError::RecordNotFound(_) => AsterError::folder_not_found(format!(
+            "Folder #{folder_id} does not exist or has been permanently removed"
+        )),
+        other => other,
+    }
 }
 
 pub(crate) async fn lock_folder_access_on<C: ConnectionTrait>(
@@ -508,7 +512,10 @@ pub(crate) async fn list_files_in_folder(
 
 #[cfg(test)]
 mod tests {
-    use super::{WorkspaceStorageScope, require_team_access, require_team_policy_group_id};
+    use super::{
+        WorkspaceStorageScope, map_folder_lookup_error, require_team_access,
+        require_team_policy_group_id,
+    };
     use crate::config::{Config, RuntimeConfig};
     use crate::db::repository::{
         policy_group_repo, policy_placement_repo, policy_repo, team_member_repo, team_repo,
@@ -574,6 +581,30 @@ mod tests {
                 crate::runtime::PrimaryAppState::new_background_task_dispatch_wakeup(),
             remote_protocol: crate::runtime::PrimaryAppState::new_remote_protocol(),
         }
+    }
+
+    #[test]
+    fn folder_lookup_error_mapping_is_specific_and_preserves_other_errors() {
+        let missing = map_folder_lookup_error(
+            42,
+            crate::errors::AsterError::record_not_found("folder #42"),
+        );
+        assert!(matches!(
+            missing,
+            crate::errors::AsterError::FolderNotFound(_)
+        ));
+        assert_eq!(
+            missing.raw_message(),
+            "Folder #42 does not exist or has been permanently removed"
+        );
+
+        let database = crate::errors::AsterError::database_operation("database unavailable");
+        let preserved = map_folder_lookup_error(42, database);
+        assert!(matches!(
+            preserved,
+            crate::errors::AsterError::DatabaseOperation(_)
+        ));
+        assert_eq!(preserved.raw_message(), "database unavailable");
     }
 
     async fn create_user(state: &impl SharedRuntimeState, username: &str) -> user::Model {

--- a/tests/files/trash.rs
+++ b/tests/files/trash.rs
@@ -126,6 +126,195 @@ async fn test_trash_restore_purge() {
 }
 
 #[actix_web::test]
+async fn test_folder_read_endpoints_return_domain_not_found_across_trash_lifecycle() {
+    let state = common::setup().await;
+    let app = create_test_app!(state.clone());
+    let (token, _) = register_and_login!(app);
+    let missing_folder_id = i64::MAX;
+
+    for suffix in ["", "/info", "/ancestors"] {
+        let req = test::TestRequest::get()
+            .uri(&format!("/api/v1/folders/{missing_folder_id}{suffix}"))
+            .insert_header(("Cookie", common::access_cookie_header(&token)))
+            .insert_header(common::csrf_header_for(&token))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            404,
+            "unexpected missing-folder status for {suffix}"
+        );
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["code"], "folder.not_found");
+        assert_eq!(body["error"]["retryable"], false);
+        assert!(
+            body["msg"]
+                .as_str()
+                .unwrap()
+                .contains("does not exist or has been permanently removed")
+        );
+    }
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/folders")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({ "name": "lifecycle-folder" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    let folder_id = body["data"]["id"].as_i64().unwrap();
+
+    let req = test::TestRequest::delete()
+        .uri(&format!("/api/v1/folders/{folder_id}"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    assert_eq!(test::call_service(&app, req).await.status(), 200);
+
+    for suffix in ["", "/info", "/ancestors"] {
+        let req = test::TestRequest::get()
+            .uri(&format!("/api/v1/folders/{folder_id}{suffix}"))
+            .insert_header(("Cookie", common::access_cookie_header(&token)))
+            .insert_header(common::csrf_header_for(&token))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 404, "unexpected status for suffix {suffix}");
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["code"], "folder.not_found");
+        assert_eq!(body["error"]["retryable"], false);
+        assert!(
+            body["msg"].as_str().unwrap().contains("is in trash"),
+            "unexpected response: {body}"
+        );
+    }
+
+    let req = test::TestRequest::delete()
+        .uri(&format!("/api/v1/trash/folder/{folder_id}"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    assert_eq!(test::call_service(&app, req).await.status(), 200);
+
+    for suffix in ["", "/info", "/ancestors"] {
+        let req = test::TestRequest::get()
+            .uri(&format!("/api/v1/folders/{folder_id}{suffix}"))
+            .insert_header(("Cookie", common::access_cookie_header(&token)))
+            .insert_header(common::csrf_header_for(&token))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 404, "unexpected status for suffix {suffix}");
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["code"], "folder.not_found");
+        assert_eq!(body["error"]["retryable"], false);
+        assert!(
+            body["msg"]
+                .as_str()
+                .unwrap()
+                .contains("does not exist or has been permanently removed"),
+            "unexpected response: {body}"
+        );
+    }
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/teams")
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({ "name": "Folder lifecycle team" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), 201);
+    let body: Value = test::read_body_json(resp).await;
+    let team_id = body["data"]["id"].as_i64().unwrap();
+    for suffix in ["", "/info", "/ancestors"] {
+        let req = test::TestRequest::get()
+            .uri(&format!(
+                "/api/v1/teams/{team_id}/folders/{missing_folder_id}{suffix}"
+            ))
+            .insert_header(("Cookie", common::access_cookie_header(&token)))
+            .insert_header(common::csrf_header_for(&token))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(
+            resp.status(),
+            404,
+            "unexpected missing team-folder status for {suffix}"
+        );
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["code"], "folder.not_found");
+        assert_eq!(body["error"]["retryable"], false);
+        assert!(
+            body["msg"]
+                .as_str()
+                .unwrap()
+                .contains("does not exist or has been permanently removed")
+        );
+    }
+    let req = test::TestRequest::post()
+        .uri(&format!("/api/v1/teams/{team_id}/folders"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .set_json(serde_json::json!({ "name": "team-lifecycle-folder" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let body: Value = test::read_body_json(resp).await;
+    let team_folder_id = body["data"]["id"].as_i64().unwrap();
+
+    let req = test::TestRequest::delete()
+        .uri(&format!("/api/v1/teams/{team_id}/folders/{team_folder_id}"))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    assert_eq!(test::call_service(&app, req).await.status(), 200);
+
+    for suffix in ["", "/info", "/ancestors"] {
+        let req = test::TestRequest::get()
+            .uri(&format!(
+                "/api/v1/teams/{team_id}/folders/{team_folder_id}{suffix}"
+            ))
+            .insert_header(("Cookie", common::access_cookie_header(&token)))
+            .insert_header(common::csrf_header_for(&token))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 404, "unexpected team status for {suffix}");
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["code"], "folder.not_found");
+        assert_eq!(body["error"]["retryable"], false);
+        assert!(body["msg"].as_str().unwrap().contains("is in trash"));
+    }
+
+    let req = test::TestRequest::delete()
+        .uri(&format!(
+            "/api/v1/teams/{team_id}/trash/folder/{team_folder_id}"
+        ))
+        .insert_header(("Cookie", common::access_cookie_header(&token)))
+        .insert_header(common::csrf_header_for(&token))
+        .to_request();
+    assert_eq!(test::call_service(&app, req).await.status(), 200);
+
+    for suffix in ["", "/info", "/ancestors"] {
+        let req = test::TestRequest::get()
+            .uri(&format!(
+                "/api/v1/teams/{team_id}/folders/{team_folder_id}{suffix}"
+            ))
+            .insert_header(("Cookie", common::access_cookie_header(&token)))
+            .insert_header(common::csrf_header_for(&token))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), 404, "unexpected team status for {suffix}");
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["code"], "folder.not_found");
+        assert_eq!(body["error"]["retryable"], false);
+        assert!(
+            body["msg"]
+                .as_str()
+                .unwrap()
+                .contains("does not exist or has been permanently removed")
+        );
+    }
+}
+
+#[actix_web::test]
 async fn test_restore_file_rejects_active_name_conflict() {
     let state = common::setup().await;
     let app = create_test_app!(state);
@@ -277,8 +466,8 @@ async fn test_trash_purge_all() {
     assert_eq!(stats.succeeded, 2);
     let purge_all_event = rx
         .try_recv()
-        .expect("purge-all task should publish one storage sync event");
-    assert_eq!(purge_all_event.kind, StorageChangeKind::SyncRequired);
+        .expect("purge-all task should publish one aggregate storage event");
+    assert_eq!(purge_all_event.kind, StorageChangeKind::TrashPurgedAll);
     assert!(purge_all_event.file_ids.is_empty());
     assert!(purge_all_event.folder_ids.is_empty());
     assert!(purge_all_event.affected_parent_ids.is_empty());


### PR DESCRIPTION
## Summary
- Coordinate route navigation with SSE and mutation refreshes so user navigation remains authoritative and URL/store/list state stay aligned.
- Add scoped `trash.purged_all` storage events, preserve full `sync.required` semantics for reconciliation, and refresh only trash/quota projections.
- Return stable `folder.not_found` errors with lifecycle-aware messages and recover personal/team file-browser routes to the nearest available ancestor or workspace root.

## Root cause
Folder navigation and background refreshes shared cancellation and commit state. A refresh captured the old folder while route navigation was pending, aborted the navigation, and left the browser URL ahead of the store. Empty-trash completion reused the broad `sync.required` event, so live file-browser views re-requested folders that had just been purged. Folder lookup also mapped missing records to a generic `not_found` error, leaving the UI without a recovery target.

## Validation
- Frontend: 3,088 tests passed across 395 files
- Rust library and files tests: 2,195 passed, 1 configured skip
- Frontend typecheck, Biome, production build, startup audit, OpenAPI generation, cargo fmt, and diff checks passed

Closes #599
Closes #600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 修复文件夹导航与数据刷新之间的竞态，避免刷新结果覆盖用户当前导航。
  - 当前文件夹被删除或移入回收站时，自动返回最近可用的上级目录或工作区根目录，并显示明确提示。
  - 统一文件夹不可用时的错误提示与 404 响应。
  - 清空回收站后正确刷新回收站内容和个人存储配额，避免不必要的当前目录刷新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->