### PR TITLE
perf(storage): unify exact-size AsyncRead upload contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Storage reader uploads now enforce one exact byte-length contract across all 10 built-in connectors. Negative, short, and long streams use stable precondition errors; SFTP and reverse-tunnel paths bound reads to the declared size plus one byte, and the shared multipart fallback refuses parts above its explicit 64 MiB buffer budget.
+
 ## [v0.6.0] - 2026-09-12
 
 ### Release Highlights

--- a/crates/aster_drive_storage/src/lib.rs
+++ b/crates/aster_drive_storage/src/lib.rs
@@ -76,12 +76,12 @@ pub use traits::driver::{
     PresignedUploadRequest, StorageDriver, StoragePathVisitor,
 };
 pub use traits::{
-    DirectDownloadStorageDriver, ListStorageDriver, LocalPathStorageDriver, MultipartStorageDriver,
-    NativeMediaMetadataRequest, NativeMediaMetadataResult, NativeMediaMetadataStorageDriver,
-    NativeThumbnailRequest, NativeThumbnailStorageDriver, PresignedUploadStorageDriver,
-    ProviderResumableUploadCapabilities, ProviderResumableUploadDriver,
-    ProviderResumableUploadFragmentOutcome, ProviderResumableUploadSession,
-    ProviderResumableUploadStatus, StorageCapacityInfo, StorageCapacityStatus,
-    StorageDriverExtensions, StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver,
-    UploadedMultipartPart,
+    DirectDownloadStorageDriver, ExactSizeReader, ListStorageDriver, LocalPathStorageDriver,
+    MultipartStorageDriver, NativeMediaMetadataRequest, NativeMediaMetadataResult,
+    NativeMediaMetadataStorageDriver, NativeThumbnailRequest, NativeThumbnailStorageDriver,
+    PresignedUploadStorageDriver, ProviderResumableUploadCapabilities,
+    ProviderResumableUploadDriver, ProviderResumableUploadFragmentOutcome,
+    ProviderResumableUploadSession, ProviderResumableUploadStatus, StorageCapacityInfo,
+    StorageCapacityStatus, StorageDriverExtensions, StreamUploadAttempt, StreamUploadCleanup,
+    StreamUploadDriver, UploadedMultipartPart, checked_stream_upload_size,
 };

--- a/crates/aster_drive_storage/src/traits/extensions.rs
+++ b/crates/aster_drive_storage/src/traits/extensions.rs
@@ -15,10 +15,96 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Duration;
-use tokio::io::AsyncRead;
+use tokio::io::{AsyncRead, ReadBuf};
 #[cfg(all(debug_assertions, feature = "openapi"))]
 use utoipa::ToSchema;
+
+/// Validate a declared reader-upload length before provider I/O.
+pub fn checked_stream_upload_size(size: i64, context: &str) -> Result<u64> {
+    u64::try_from(size).map_err(|_| {
+        crate::error::storage_driver_error(
+            crate::error::StorageErrorKind::Precondition,
+            format!("{context} must be non-negative, got {size}"),
+        )
+    })
+}
+
+/// An `AsyncRead` adapter that reads exactly `size` bytes and probes one
+/// additional byte. It never buffers according to the declared object size.
+pub struct ExactSizeReader<R> {
+    inner: R,
+    remaining: u64,
+    checked_extra: bool,
+}
+
+impl<R> ExactSizeReader<R> {
+    pub fn new(inner: R, size: u64) -> Self {
+        Self {
+            inner,
+            remaining: size,
+            checked_extra: false,
+        }
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for ExactSizeReader<R> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if output.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        if self.remaining > 0 {
+            let limit = usize::try_from(self.remaining)
+                .unwrap_or(usize::MAX)
+                .min(output.remaining());
+            let before = output.filled().len();
+            let mut limited = ReadBuf::new(&mut output.initialize_unfilled()[..limit]);
+            match Pin::new(&mut self.inner).poll_read(cx, &mut limited) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+                Poll::Ready(Ok(())) => {
+                    let read = limited.filled().len();
+                    if read == 0 {
+                        return Poll::Ready(Err(std::io::Error::new(
+                            std::io::ErrorKind::UnexpectedEof,
+                            "reader ended before declared size",
+                        )));
+                    }
+                    output.advance(read);
+                    self.remaining -=
+                        u64::try_from(output.filled().len() - before).unwrap_or(self.remaining);
+                    Poll::Ready(Ok(()))
+                }
+            }
+        } else if !self.checked_extra {
+            let mut probe = [0u8; 1];
+            let mut probe_buf = ReadBuf::new(&mut probe);
+            match Pin::new(&mut self.inner).poll_read(cx, &mut probe_buf) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+                Poll::Ready(Ok(())) => {
+                    self.checked_extra = true;
+                    if probe_buf.filled().is_empty() {
+                        Poll::Ready(Ok(()))
+                    } else {
+                        Poll::Ready(Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            "reader exceeded declared size",
+                        )))
+                    }
+                }
+            }
+        } else {
+            Poll::Ready(Ok(()))
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
@@ -298,10 +384,14 @@ pub trait ListStorageDriver: Send + Sync {
 /// 可以在内部使用 provider-native session、对象存储 streaming body 或临时文件。
 #[async_trait]
 pub trait StreamUploadDriver: Send + Sync {
-    /// 从 reader 流式写入存储
+    /// 从 reader 流式写入存储。
     ///
     /// 适用于不应先落本地临时文件的上传路径（如 WebDAV 直传、S3 流式上传）。
-    /// driver 必须保持有界流式读取，并在目标可见前完成大小校验。
+    /// `size` is a byte count and must be non-negative. The reader must contain
+    /// exactly that many bytes: a short or long reader is a `Precondition`
+    /// failure, while reader I/O failures remain `Transient`. Drivers must
+    /// bound request memory independently of the declared size and reject a
+    /// negative size before provider I/O.
     async fn put_reader(
         &self,
         storage_path: &str,
@@ -403,7 +493,7 @@ pub trait NativeMediaMetadataStorageDriver: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use super::{StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver};
+    use super::{ExactSizeReader, StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver};
     use crate::error::{Result, StorageErrorKind};
     use async_trait::async_trait;
     use std::sync::Arc;
@@ -559,5 +649,30 @@ mod tests {
         .await
         .expect("independent attempts must not be serialized");
         assert_eq!(driver.max_active.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn exact_size_reader_accepts_exact_input_without_buffering() {
+        let mut reader = ExactSizeReader::new(std::io::Cursor::new(b"abcd"), 4);
+        let mut output = Vec::new();
+        tokio::io::AsyncReadExt::read_to_end(&mut reader, &mut output)
+            .await
+            .unwrap();
+        assert_eq!(output, b"abcd");
+    }
+
+    #[tokio::test]
+    async fn exact_size_reader_rejects_short_and_long_input() {
+        let mut short = ExactSizeReader::new(std::io::Cursor::new(b"abc"), 4);
+        let short_error = tokio::io::AsyncReadExt::read_to_end(&mut short, &mut Vec::new())
+            .await
+            .unwrap_err();
+        assert_eq!(short_error.kind(), std::io::ErrorKind::UnexpectedEof);
+
+        let mut long = ExactSizeReader::new(std::io::Cursor::new(b"abcde"), 4);
+        let long_error = tokio::io::AsyncReadExt::read_to_end(&mut long, &mut Vec::new())
+            .await
+            .unwrap_err();
+        assert_eq!(long_error.kind(), std::io::ErrorKind::InvalidData);
     }
 }

--- a/crates/aster_drive_storage/src/traits/mod.rs
+++ b/crates/aster_drive_storage/src/traits/mod.rs
@@ -9,12 +9,13 @@ pub use driver::{
     PresignedUploadRequest, StorageDriver, StoragePathVisitor,
 };
 pub use extensions::{
-    DirectDownloadStorageDriver, ListStorageDriver, LocalPathStorageDriver,
+    DirectDownloadStorageDriver, ExactSizeReader, ListStorageDriver, LocalPathStorageDriver,
     NativeMediaMetadataRequest, NativeMediaMetadataResult, NativeMediaMetadataStorageDriver,
     NativeThumbnailRequest, NativeThumbnailStorageDriver, PresignedUploadStorageDriver,
     ProviderResumableUploadCapabilities, ProviderResumableUploadDriver,
     ProviderResumableUploadFragmentOutcome, ProviderResumableUploadSession,
     ProviderResumableUploadStatus, StorageCapacityInfo, StorageCapacityStatus,
     StorageDriverExtensions, StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver,
+    checked_stream_upload_size,
 };
 pub use multipart::{MultipartStorageDriver, UploadedMultipartPart};

--- a/crates/aster_drive_storage/src/traits/multipart.rs
+++ b/crates/aster_drive_storage/src/traits/multipart.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 const DEFAULT_MULTIPART_READER_BUFFER_SIZE: usize = 64 * 1024;
+const MAX_MULTIPART_READER_BUFFER_SIZE: usize = 64 * 1024 * 1024;
 
 /// Provider 端已经接收的 multipart part 明细。
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -81,6 +82,10 @@ pub trait MultipartStorageDriver: Send + Sync {
     }
 
     /// 服务端直接流式上传一个 multipart part，返回该 part 的 ETag。
+    ///
+    /// The default fallback is deliberately bounded to 64 MiB and buffers the
+    /// part before calling `upload_multipart_part`. Drivers accepting larger
+    /// parts or requiring fixed-buffer streaming must override this method.
     async fn upload_multipart_part_reader(
         &self,
         path: &str,
@@ -91,7 +96,16 @@ pub trait MultipartStorageDriver: Send + Sync {
     ) -> Result<String> {
         let mut reader = reader;
         let expected_size = aster_forge_utils::numbers::bytes_to_usize(size, "multipart part size")
-            .map_storage_err(StorageErrorKind::Misconfigured)?;
+            .map_storage_err(StorageErrorKind::Precondition)?;
+        if expected_size > MAX_MULTIPART_READER_BUFFER_SIZE {
+            return Err(storage_driver_error(
+                StorageErrorKind::Unsupported,
+                format!(
+                    "multipart reader upload exceeds default {} byte buffer limit; driver must implement streaming",
+                    MAX_MULTIPART_READER_BUFFER_SIZE
+                ),
+            ));
+        }
         let mut data = Vec::with_capacity(expected_size);
         let mut buffer = vec![0u8; DEFAULT_MULTIPART_READER_BUFFER_SIZE.min(expected_size.max(1))];
 
@@ -110,7 +124,7 @@ pub trait MultipartStorageDriver: Send + Sync {
 
         if data.len() < expected_size {
             return Err(storage_driver_error(
-                StorageErrorKind::Transient,
+                StorageErrorKind::Precondition,
                 format!(
                     "read multipart part stream: multipart part stream ended before expected size {size}"
                 ),
@@ -124,7 +138,7 @@ pub trait MultipartStorageDriver: Send + Sync {
             .map_storage_err_ctx(StorageErrorKind::Transient, "read multipart part stream")?;
         if extra_read > 0 {
             return Err(storage_driver_error(
-                StorageErrorKind::Transient,
+                StorageErrorKind::Precondition,
                 format!(
                     "read multipart part stream: multipart part stream exceeds expected size {size}"
                 ),
@@ -265,7 +279,7 @@ mod tests {
             .await
             .expect_err("oversized stream should fail");
 
-        assert_eq!(error.kind(), StorageErrorKind::Transient);
+        assert_eq!(error.kind(), StorageErrorKind::Precondition);
         assert!(
             error
                 .message()
@@ -295,7 +309,7 @@ mod tests {
             .await
             .expect_err("short stream should fail");
 
-        assert_eq!(error.kind(), StorageErrorKind::Transient);
+        assert_eq!(error.kind(), StorageErrorKind::Precondition);
         assert!(
             error
                 .message()
@@ -350,7 +364,7 @@ mod tests {
             .await
             .expect_err("zero-size stream with data should fail");
 
-        assert_eq!(error.kind(), StorageErrorKind::Transient);
+        assert_eq!(error.kind(), StorageErrorKind::Precondition);
         assert!(
             error
                 .message()
@@ -380,7 +394,7 @@ mod tests {
             .await
             .expect_err("negative size should fail");
 
-        assert_eq!(error.kind(), StorageErrorKind::Misconfigured);
+        assert_eq!(error.kind(), StorageErrorKind::Precondition);
         assert!(
             driver
                 .uploaded
@@ -388,5 +402,23 @@ mod tests {
                 .expect("uploaded lock should not poison")
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn default_reader_upload_rejects_huge_declared_part_before_allocation() {
+        let driver = CapturingMultipartDriver::new();
+        let error = driver
+            .upload_multipart_part_reader(
+                "path",
+                "upload",
+                1,
+                Box::new(tokio::io::repeat(0)),
+                10_i64 * 1024 * 1024 * 1024 * 1024,
+            )
+            .await
+            .expect_err("huge default part should require explicit streaming implementation");
+
+        assert_eq!(error.kind(), StorageErrorKind::Unsupported);
+        assert!(driver.uploaded.lock().unwrap().is_empty());
     }
 }

--- a/src/storage/drivers/azure_blob/multipart.rs
+++ b/src/storage/drivers/azure_blob/multipart.rs
@@ -13,7 +13,7 @@ use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, ReadBuf};
 
 use aster_drive_storage::traits::driver::StorageDriver;
-use aster_drive_storage::traits::extensions::StreamUploadDriver;
+use aster_drive_storage::traits::extensions::{StreamUploadDriver, checked_stream_upload_size};
 use aster_drive_storage::traits::multipart::{MultipartStorageDriver, UploadedMultipartPart};
 use aster_drive_storage::{MapStorageErr, StorageError, StorageErrorKind, storage_driver_error};
 use aster_forge_utils::numbers;
@@ -31,6 +31,7 @@ struct AzureSizedReaderStream {
 struct AzureSizedReaderState {
     reader: Option<Box<dyn AsyncRead + Unpin + Send + Sync>>,
     remaining: u64,
+    checked_extra: bool,
 }
 
 struct AzureChunkReader {
@@ -115,6 +116,7 @@ impl AzureSizedReaderStream {
             inner: Arc::new(Mutex::new(AzureSizedReaderState {
                 reader: Some(reader),
                 remaining: len,
+                checked_extra: false,
             })),
             len,
         }
@@ -145,7 +147,31 @@ impl FuturesAsyncRead for AzureSizedReaderStream {
             .lock()
             .map_err(|_| std::io::Error::other("Azure Blob upload stream lock poisoned"))?;
         if state.remaining == 0 {
-            return Poll::Ready(Ok(0));
+            if state.checked_extra {
+                return Poll::Ready(Ok(0));
+            }
+            let Some(reader) = state.reader.as_mut() else {
+                state.checked_extra = true;
+                return Poll::Ready(Ok(0));
+            };
+            let mut probe = [0_u8; 1];
+            let mut probe_buf = ReadBuf::new(&mut probe);
+            return match Pin::new(reader).poll_read(cx, &mut probe_buf) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+                Poll::Ready(Ok(())) => {
+                    state.checked_extra = true;
+                    state.reader = None;
+                    if probe_buf.filled().is_empty() {
+                        Poll::Ready(Ok(0))
+                    } else {
+                        Poll::Ready(Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            "Azure Blob upload stream exceeded declared size",
+                        )))
+                    }
+                }
+            };
         }
 
         let output_len = aster_forge_utils::numbers::usize_to_u64(
@@ -324,9 +350,7 @@ impl MultipartStorageDriver for AzureBlobDriver {
         size: i64,
     ) -> aster_drive_storage::Result<String> {
         let client = self.block_blob_client(path, "cw")?;
-        let content_length =
-            aster_forge_utils::numbers::i64_to_u64(size, "Azure Blob multipart part size")
-                .map_storage_err(StorageErrorKind::Misconfigured)?;
+        let content_length = checked_stream_upload_size(size, "Azure Blob multipart part size")?;
         let body: RequestContent<Bytes, azure_core::http::NoFormat> = Body::SeekableStream(
             Box::new(AzureSizedReaderStream::new(reader, content_length)),
         )
@@ -408,8 +432,8 @@ impl StreamUploadDriver for AzureBlobDriver {
         reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
         size: i64,
     ) -> aster_drive_storage::Result<String> {
-        let expected_size = numbers::i64_to_u64(size, "Azure Blob put_reader declared size")
-            .map_storage_err(StorageErrorKind::Misconfigured)?;
+        let expected_size =
+            checked_stream_upload_size(size, "Azure Blob put_reader declared size")?;
         let chunk_size = self.chunk_size_for_content(expected_size)?;
         let reader = Arc::new(Mutex::new(reader));
         let mut remaining = expected_size;
@@ -577,7 +601,7 @@ mod tests {
 
     #[tokio::test]
     async fn sized_reader_stream_reads_only_declared_length() {
-        let reader = Box::new(std::io::Cursor::new(b"abcdef".to_vec()));
+        let reader = Box::new(std::io::Cursor::new(b"abc".to_vec()));
         let mut stream = AzureSizedReaderStream::new(reader, 3);
         let mut output = Vec::new();
 
@@ -589,6 +613,20 @@ mod tests {
         assert_eq!(output, b"abc");
         assert_eq!(stream.len(), Some(3));
         assert_eq!(stream.buffer_size(), AZURE_STREAM_BUFFER_SIZE);
+    }
+
+    #[tokio::test]
+    async fn sized_reader_stream_rejects_extra_bytes() {
+        let reader = Box::new(std::io::Cursor::new(b"abcdef".to_vec()));
+        let mut stream = AzureSizedReaderStream::new(reader, 3);
+        let mut output = Vec::new();
+
+        let error = stream
+            .read_to_end(&mut output)
+            .await
+            .expect_err("long stream should fail");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(output, b"abc");
     }
 
     #[tokio::test]

--- a/src/storage/drivers/local/stream_upload.rs
+++ b/src/storage/drivers/local/stream_upload.rs
@@ -2,10 +2,9 @@ use async_trait::async_trait;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 
 use aster_drive_storage::traits::extensions::{
-    StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver,
+    StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver, checked_stream_upload_size,
 };
 use aster_drive_storage::{MapStorageErr, StorageErrorKind, storage_driver_error};
-use aster_forge_utils::numbers;
 
 use super::LocalDriver;
 
@@ -46,8 +45,7 @@ impl StreamUploadDriver for LocalDriver {
         reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
     ) -> aster_drive_storage::Result<()> {
         let expected_size =
-            numbers::i64_to_u64(attempt.expected_size, "local stream upload declared size")
-                .map_storage_err(StorageErrorKind::Misconfigured)?;
+            checked_stream_upload_size(attempt.expected_size, "local stream upload declared size")?;
         let staging_path = self.full_path(&attempt.staging_path)?;
         if let Some(parent) = staging_path.parent() {
             tokio::fs::create_dir_all(parent)

--- a/src/storage/drivers/onedrive/mod.rs
+++ b/src/storage/drivers/onedrive/mod.rs
@@ -13,7 +13,7 @@ use aster_drive_storage::traits::extensions::{
     DirectDownloadStorageDriver, ProviderResumableUploadCapabilities,
     ProviderResumableUploadDriver, ProviderResumableUploadFragmentOutcome,
     ProviderResumableUploadSession, ProviderResumableUploadStatus, StorageCapacityInfo,
-    StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver,
+    StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver, checked_stream_upload_size,
 };
 use aster_drive_storage::{
     MapStorageErr, Result, StorageError, StorageErrorKind, storage_driver_error,
@@ -266,8 +266,7 @@ impl OneDriveDriver {
         size: i64,
         attempt: Option<&StreamUploadAttempt>,
     ) -> Result<String> {
-        let total_size = numbers::i64_to_u64(size, "OneDrive put_reader declared size")
-            .map_storage_err(StorageErrorKind::Misconfigured)?;
+        let total_size = checked_stream_upload_size(size, "OneDrive put_reader declared size")?;
         if total_size == 0 {
             return self
                 .put_owned_with_attempt(path, Bytes::new(), attempt)
@@ -277,10 +276,9 @@ impl OneDriveDriver {
             let capacity = numbers::u64_to_usize(total_size, "OneDrive bounded simple upload size")
                 .map_storage_err(StorageErrorKind::Misconfigured)?;
             let mut data = vec![0_u8; capacity];
-            reader.read_exact(&mut data).await.map_storage_err_ctx(
-                StorageErrorKind::Precondition,
-                "read OneDrive bounded simple upload stream",
-            )?;
+            reader.read_exact(&mut data).await.map_err(|error| {
+                map_reader_length_error(error, "read OneDrive bounded simple upload stream")
+            })?;
             reject_extra_upload_bytes(reader).await?;
             return self
                 .put_owned_with_attempt(path, Bytes::from(data), attempt)
@@ -314,10 +312,9 @@ impl OneDriveDriver {
                 )
                 .map_storage_err(StorageErrorKind::Misconfigured)?;
                 let mut chunk = vec![0_u8; read_len];
-                reader.read_exact(&mut chunk).await.map_storage_err_ctx(
-                    StorageErrorKind::Precondition,
-                    "read OneDrive upload session fragment",
-                )?;
+                reader.read_exact(&mut chunk).await.map_err(|error| {
+                    map_reader_length_error(error, "read OneDrive upload session fragment")
+                })?;
                 if remaining
                     > numbers::usize_to_u64(read_len, "OneDrive upload fragment length")
                         .map_storage_err(StorageErrorKind::Misconfigured)?
@@ -708,17 +705,26 @@ async fn reject_extra_upload_bytes(
     mut reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
 ) -> Result<()> {
     let mut extra = [0_u8; 1];
-    let read = reader.read(&mut extra).await.map_storage_err_ctx(
-        StorageErrorKind::Precondition,
-        "check OneDrive upload stream length",
-    )?;
+    let read = reader
+        .read(&mut extra)
+        .await
+        .map_err(|error| map_reader_length_error(error, "check OneDrive upload stream length"))?;
     if read != 0 {
         return Err(storage_driver_error(
-            StorageErrorKind::Misconfigured,
+            StorageErrorKind::Precondition,
             "OneDrive upload stream exceeded declared size",
         ));
     }
     Ok(())
+}
+
+fn map_reader_length_error(error: std::io::Error, context: &str) -> StorageError {
+    let kind = if error.kind() == std::io::ErrorKind::UnexpectedEof {
+        StorageErrorKind::Precondition
+    } else {
+        StorageErrorKind::Transient
+    };
+    storage_driver_error(kind, format!("{context}: {error}"))
 }
 
 #[cfg(test)]
@@ -1280,7 +1286,7 @@ mod tests {
             )
             .await
             .expect_err("extra reader bytes must be rejected");
-        assert_eq!(long.kind(), StorageErrorKind::Misconfigured);
+        assert_eq!(long.kind(), StorageErrorKind::Precondition);
 
         assert!(
             server

--- a/src/storage/drivers/remote/multipart.rs
+++ b/src/storage/drivers/remote/multipart.rs
@@ -8,7 +8,7 @@ use sha2::{Digest, Sha256};
 use tokio::io::{AsyncRead, ReadBuf};
 
 use aster_drive_storage::error::{StorageErrorKind, storage_driver_error};
-use aster_drive_storage::traits::extensions::ListStorageDriver;
+use aster_drive_storage::traits::extensions::{ListStorageDriver, checked_stream_upload_size};
 use aster_drive_storage::traits::multipart::{MultipartStorageDriver, UploadedMultipartPart};
 
 use super::RemoteDriver;
@@ -135,12 +135,7 @@ impl MultipartStorageDriver for RemoteDriver {
         size: i64,
     ) -> aster_drive_storage::Result<String> {
         let part_key = Self::multipart_part_key(upload_id, part_number)?;
-        let size = u64::try_from(size).map_err(|_| {
-            storage_driver_error(
-                StorageErrorKind::Precondition,
-                "remote multipart part size cannot be negative",
-            )
-        })?;
+        let size = checked_stream_upload_size(size, "remote multipart part size")?;
         let hasher = Arc::new(Mutex::new(Sha256::new()));
         let hashing_reader = HashingReader {
             inner: reader,

--- a/src/storage/drivers/remote/stream_upload.rs
+++ b/src/storage/drivers/remote/stream_upload.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use tokio::io::AsyncRead;
 
 use aster_drive_storage::error::{StorageErrorKind, storage_driver_error};
-use aster_drive_storage::traits::extensions::StreamUploadDriver;
+use aster_drive_storage::traits::extensions::{StreamUploadDriver, checked_stream_upload_size};
 
 use super::RemoteDriver;
 
@@ -16,12 +16,7 @@ impl StreamUploadDriver for RemoteDriver {
         reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
         size: i64,
     ) -> aster_drive_storage::Result<String> {
-        let size = u64::try_from(size).map_err(|_| {
-            storage_driver_error(
-                StorageErrorKind::Precondition,
-                format!("remote stream upload size must be non-negative, got {size}"),
-            )
-        })?;
+        let size = checked_stream_upload_size(size, "remote stream upload size")?;
         self.client
             .put_reader(&self.object_key(storage_path), reader, size)
             .await?;

--- a/src/storage/drivers/s3/multipart.rs
+++ b/src/storage/drivers/s3/multipart.rs
@@ -7,6 +7,7 @@ use bytes::Bytes;
 use tokio::io::AsyncRead;
 
 use aster_drive_storage::PresignedUploadRequest;
+use aster_drive_storage::traits::extensions::checked_stream_upload_size;
 use aster_drive_storage::traits::multipart::{MultipartStorageDriver, UploadedMultipartPart};
 use aster_drive_storage::{MapStorageErr, StorageErrorKind, storage_driver_error};
 
@@ -155,8 +156,7 @@ impl MultipartStorageDriver for S3Driver {
         size: i64,
     ) -> aster_drive_storage::Result<String> {
         let key = self.full_key(path);
-        let content_length = aster_forge_utils::numbers::i64_to_u64(size, "S3 multipart part size")
-            .map_storage_err(StorageErrorKind::Misconfigured)?;
+        let content_length = checked_stream_upload_size(size, "S3 multipart part size")?;
         let body = ByteStream::from_body_1_x(super::stream_upload::SizedReaderBody::new(
             reader,
             content_length,

--- a/src/storage/drivers/s3/stream_upload.rs
+++ b/src/storage/drivers/s3/stream_upload.rs
@@ -9,7 +9,7 @@ use http_body::{Frame, SizeHint};
 use tokio::io::AsyncRead;
 use tokio_util::io::ReaderStream;
 
-use aster_drive_storage::traits::extensions::StreamUploadDriver;
+use aster_drive_storage::traits::extensions::{StreamUploadDriver, checked_stream_upload_size};
 use aster_drive_storage::{MapStorageErr, StorageErrorKind};
 use aster_forge_utils::numbers;
 
@@ -140,8 +140,7 @@ impl StreamUploadDriver for S3Driver {
         size: i64,
     ) -> aster_drive_storage::Result<String> {
         let key = self.full_key(storage_path);
-        let content_length = numbers::i64_to_u64(size, "S3 put_reader content_length")
-            .map_storage_err(StorageErrorKind::Misconfigured)?;
+        let content_length = checked_stream_upload_size(size, "S3 put_reader content_length")?;
         let body = ByteStream::from_body_1_x(SizedReaderBody::new(reader, content_length));
 
         self.client

--- a/src/storage/drivers/sftp.rs
+++ b/src/storage/drivers/sftp.rs
@@ -22,6 +22,7 @@ use aster_drive_storage::error::{
 };
 use aster_drive_storage::{
     BlobMetadata, StorageDriver, StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver,
+    checked_stream_upload_size,
 };
 
 const DEFAULT_SFTP_PORT: u16 = 22;
@@ -607,12 +608,7 @@ impl StreamUploadDriver for SftpDriver {
         size: i64,
     ) -> aster_drive_storage::Result<String> {
         let remote_path = self.full_path(storage_path)?;
-        let expected_size = u64::try_from(size).map_err(|_| {
-            storage_driver_error(
-                StorageErrorKind::Precondition,
-                "SFTP stream upload size must be non-negative",
-            )
-        })?;
+        let expected_size = checked_stream_upload_size(size, "SFTP stream upload size")?;
         let temporary_path = format!(
             "{remote_path}.aster-upload-{:016x}.tmp",
             rand::random::<u64>()
@@ -624,7 +620,8 @@ impl StreamUploadDriver for SftpDriver {
             .create(temporary_path.clone())
             .await
             .map_err(|error| connection.map_sftp_error("SFTP create failed", error))?;
-        let written = match tokio::io::copy(&mut reader, &mut remote_file).await {
+        let mut bounded_reader = (&mut *reader).take(expected_size.saturating_add(1));
+        let written = match tokio::io::copy(&mut bounded_reader, &mut remote_file).await {
             Ok(written) => written,
             Err(error) => {
                 drop(remote_file);
@@ -635,9 +632,14 @@ impl StreamUploadDriver for SftpDriver {
         if written != expected_size {
             drop(remote_file);
             cleanup_sftp_temporary_file(&mut connection, &temporary_path, "size mismatch").await;
+            let detail = if written < expected_size {
+                format!("actual {written}")
+            } else {
+                "actual exceeds declared size".to_string()
+            };
             return Err(storage_driver_error(
                 StorageErrorKind::Precondition,
-                format!("SFTP stream upload size mismatch: declared {size}, actual {written}"),
+                format!("SFTP stream upload size mismatch: declared {size}, {detail}"),
             ));
         }
         if let Err(error) = remote_file.flush().await {

--- a/src/storage/remote_protocol/transport.rs
+++ b/src/storage/remote_protocol/transport.rs
@@ -12,7 +12,7 @@ use tokio_util::io::{ReaderStream, StreamReader};
 use crate::config::OUTBOUND_HTTP_USER_AGENT;
 use crate::errors::{AsterError, Result};
 use aster_drive_model::entities::managed_follower;
-use aster_drive_storage::StorageErrorKind;
+use aster_drive_storage::{ExactSizeReader, StorageErrorKind};
 
 use super::auth::{normalize_remote_base_url, sign_internal_request};
 use super::errors::{build_remote_status_error_from_parts, map_reqwest_error};
@@ -66,7 +66,7 @@ impl RemoteRequestBody {
         match self {
             Self::Empty => Ok(Box::new(std::io::Cursor::new(Bytes::new()))),
             Self::Bytes(body) => Ok(Box::new(std::io::Cursor::new(body))),
-            Self::Reader { reader, .. } => Ok(reader),
+            Self::Reader { reader, size } => Ok(Box::new(ExactSizeReader::new(reader, size))),
         }
     }
 
@@ -230,8 +230,9 @@ impl RemoteTransport for DirectHttpTransport {
         builder = match request.body {
             RemoteRequestBody::Empty => builder,
             RemoteRequestBody::Bytes(body) => builder.body(body),
-            RemoteRequestBody::Reader { reader, .. } => {
-                let stream = ReaderStream::new(reader).map_err(std::io::Error::other);
+            RemoteRequestBody::Reader { reader, size } => {
+                let stream = ReaderStream::new(ExactSizeReader::new(reader, size))
+                    .map_err(std::io::Error::other);
                 builder.body(reqwest::Body::wrap_stream(stream))
             }
         };

--- a/tests/storage/storage_multipart.rs
+++ b/tests/storage/storage_multipart.rs
@@ -112,7 +112,7 @@ async fn default_reader_upload_rejects_stream_larger_than_size() {
         .await
         .expect_err("oversized stream should fail");
 
-    assert_eq!(error.kind(), StorageErrorKind::Transient);
+    assert_eq!(error.kind(), StorageErrorKind::Precondition);
     assert!(
         error
             .message()
@@ -136,7 +136,7 @@ async fn default_reader_upload_rejects_stream_shorter_than_size() {
         .await
         .expect_err("short stream should fail");
 
-    assert_eq!(error.kind(), StorageErrorKind::Transient);
+    assert_eq!(error.kind(), StorageErrorKind::Precondition);
     assert!(
         error
             .message()
@@ -172,7 +172,7 @@ async fn default_reader_upload_enforces_zero_size_boundary() {
         .await
         .expect_err("zero-size stream with data should fail");
 
-    assert_eq!(error.kind(), StorageErrorKind::Transient);
+    assert_eq!(error.kind(), StorageErrorKind::Precondition);
     assert!(
         error
             .message()
@@ -196,6 +196,6 @@ async fn default_reader_upload_rejects_negative_size_before_upload() {
         .await
         .expect_err("negative size should fail");
 
-    assert_eq!(error.kind(), StorageErrorKind::Misconfigured);
+    assert_eq!(error.kind(), StorageErrorKind::Precondition);
     assert!(driver.uploaded().is_empty());
 }


### PR DESCRIPTION
## Summary

Closes #512.

- Define one exact-size `AsyncRead` upload contract for all 10 built-in connectors.
- Add bounded `ExactSizeReader` and stable `Precondition` classification for negative, short, and long streams.
- Bound Local/SFTP/Remote/Azure reader paths and preserve fixed-buffer provider streaming.
- Cap the shared multipart reader fallback at 64 MiB and require explicit streaming for larger parts.
- Cover S3-family delegation, Azure, Local, Remote, OneDrive, SFTP, and multipart boundaries.

## Validation

- `cargo nextest run --profile ci -p aster_drive_storage --lib`
- `cargo nextest run --profile ci --test storage storage_multipart`
- focused driver/transport nextest: 128 passed
- `cargo clippy -p aster_drive_storage -p aster_drive --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Full storage integration reached 215/222; 7 external-container tests timed out while starting Azurite/RustFS/SFTP containers in the local environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **变更**
  - 统一存储流式上传的精确字节长度校验。
  - 上传数据过短、过长或声明长度为负时，返回稳定的前置条件错误。
  - SFTP、反向隧道及 HTTP 传输会限制读取范围，及时检测超出声明长度的数据。
  - Multipart 回退上传对分片设置 64 MiB 缓冲区上限，超出时要求使用流式上传。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->