### PR TITLE
perf(storage): enforce exact upload stream sizes

### DIFF
--- a/crates/aster_drive_storage/src/lib.rs
+++ b/crates/aster_drive_storage/src/lib.rs
@@ -76,12 +76,12 @@ pub use traits::driver::{
     PresignedUploadRequest, StorageDriver, StoragePathVisitor,
 };
 pub use traits::{
-    DirectDownloadStorageDriver, ListStorageDriver, LocalPathStorageDriver, MultipartStorageDriver,
-    NativeMediaMetadataRequest, NativeMediaMetadataResult, NativeMediaMetadataStorageDriver,
-    NativeThumbnailRequest, NativeThumbnailStorageDriver, PresignedUploadStorageDriver,
-    ProviderResumableUploadCapabilities, ProviderResumableUploadDriver,
-    ProviderResumableUploadFragmentOutcome, ProviderResumableUploadSession,
-    ProviderResumableUploadStatus, StorageCapacityInfo, StorageCapacityStatus,
-    StorageDriverExtensions, StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver,
-    UploadedMultipartPart,
+    DirectDownloadStorageDriver, ExactSizeReader, ListStorageDriver, LocalPathStorageDriver,
+    MultipartStorageDriver, NativeMediaMetadataRequest, NativeMediaMetadataResult,
+    NativeMediaMetadataStorageDriver, NativeThumbnailRequest, NativeThumbnailStorageDriver,
+    PresignedUploadStorageDriver, ProviderResumableUploadCapabilities,
+    ProviderResumableUploadDriver, ProviderResumableUploadFragmentOutcome,
+    ProviderResumableUploadSession, ProviderResumableUploadStatus, StorageCapacityInfo,
+    StorageCapacityStatus, StorageDriverExtensions, StreamUploadAttempt, StreamUploadCleanup,
+    StreamUploadDriver, UploadedMultipartPart, checked_upload_size, exact_size_error_kind,
 };

--- a/crates/aster_drive_storage/src/traits/extensions.rs
+++ b/crates/aster_drive_storage/src/traits/extensions.rs
@@ -15,10 +15,133 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Duration;
-use tokio::io::AsyncRead;
+use tokio::io::{AsyncRead, ReadBuf};
 #[cfg(all(debug_assertions, feature = "openapi"))]
 use utoipa::ToSchema;
+
+/// Reject negative declared sizes before provider I/O.
+pub fn checked_upload_size(size: i64, context: &str) -> Result<u64> {
+    u64::try_from(size).map_err(|_| {
+        crate::error::storage_driver_error(
+            crate::error::StorageErrorKind::Precondition,
+            format!("{context} must be non-negative, got {size}"),
+        )
+    })
+}
+
+/// Classify only errors emitted by `ExactSizeReader` itself. Provider adapters
+/// must not infer a length violation from `UnexpectedEof`/`InvalidData` alone,
+/// because underlying readers may use those kinds for transient I/O failures.
+pub fn exact_size_error_kind(error: &std::io::Error) -> Option<crate::error::StorageErrorKind> {
+    if matches!(
+        error.kind(),
+        std::io::ErrorKind::UnexpectedEof | std::io::ErrorKind::InvalidData
+    ) && (error
+        .to_string()
+        .contains("reader ended before declared size")
+        || error.to_string().contains("reader exceeded declared size"))
+    {
+        Some(crate::error::StorageErrorKind::Precondition)
+    } else {
+        None
+    }
+}
+
+/// Bounded exact-length reader. It withholds the final declared byte until
+/// one extra byte has been probed, preventing fixed-length transports from
+/// silently truncating oversized input.
+pub struct ExactSizeReader<R> {
+    inner: R,
+    remaining: u64,
+    final_byte: Option<u8>,
+    eof_checked: bool,
+}
+
+impl<R> ExactSizeReader<R> {
+    pub fn new(inner: R, size: u64) -> Self {
+        Self {
+            inner,
+            remaining: size,
+            final_byte: None,
+            eof_checked: false,
+        }
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for ExactSizeReader<R> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        output: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if output.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        if self.remaining > 1 {
+            let limit = usize::try_from(self.remaining - 1)
+                .unwrap_or(usize::MAX)
+                .min(output.remaining());
+            let mut limited = ReadBuf::new(&mut output.initialize_unfilled()[..limit]);
+            return match Pin::new(&mut self.inner).poll_read(cx, &mut limited) {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+                Poll::Ready(Ok(())) => {
+                    let read = limited.filled().len();
+                    if read == 0 {
+                        Poll::Ready(Err(std::io::Error::new(
+                            std::io::ErrorKind::UnexpectedEof,
+                            "reader ended before declared size",
+                        )))
+                    } else {
+                        output.advance(read);
+                        self.remaining -= u64::try_from(read).unwrap_or(self.remaining);
+                        Poll::Ready(Ok(()))
+                    }
+                }
+            };
+        }
+        if self.remaining == 1 && self.final_byte.is_none() {
+            let mut byte = [0u8; 1];
+            let mut buffer = ReadBuf::new(&mut byte);
+            match Pin::new(&mut self.inner).poll_read(cx, &mut buffer) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+                Poll::Ready(Ok(())) if buffer.filled().is_empty() => {
+                    return Poll::Ready(Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "reader ended before declared size",
+                    )));
+                }
+                Poll::Ready(Ok(())) => {
+                    self.final_byte = Some(byte[0]);
+                    self.remaining = 0;
+                }
+            }
+        }
+        if !self.eof_checked {
+            let mut extra = [0u8; 1];
+            let mut buffer = ReadBuf::new(&mut extra);
+            match Pin::new(&mut self.inner).poll_read(cx, &mut buffer) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+                Poll::Ready(Ok(())) if !buffer.filled().is_empty() => {
+                    return Poll::Ready(Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "reader exceeded declared size",
+                    )));
+                }
+                Poll::Ready(Ok(())) => self.eof_checked = true,
+            }
+        }
+        if let Some(byte) = self.final_byte.take() {
+            output.put_slice(&[byte]);
+        }
+        Poll::Ready(Ok(()))
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(all(debug_assertions, feature = "openapi"), derive(ToSchema))]
@@ -403,12 +526,60 @@ pub trait NativeMediaMetadataStorageDriver: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use super::{StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver};
+    use super::{
+        ExactSizeReader, StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver,
+        checked_upload_size,
+    };
     use crate::error::{Result, StorageErrorKind};
     use async_trait::async_trait;
+    use std::io::Cursor;
+    use std::pin::Pin;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use tokio::io::AsyncRead;
+    use std::task::{Context, Poll};
+    use tokio::io::{AsyncRead, ReadBuf};
+
+    struct PendingOnceReader {
+        inner: Cursor<Vec<u8>>,
+        pending: bool,
+    }
+
+    impl AsyncRead for PendingOnceReader {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            output: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            if self.pending {
+                self.pending = false;
+                cx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
+            Pin::new(&mut self.inner).poll_read(cx, output)
+        }
+    }
+
+    struct ErrorReader;
+
+    impl AsyncRead for ErrorReader {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _output: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Err(std::io::Error::other("synthetic reader failure")))
+        }
+    }
+
+    #[test]
+    fn checked_upload_size_covers_zero_max_and_negative_boundaries() {
+        assert_eq!(checked_upload_size(0, "size").expect("zero is valid"), 0);
+        assert_eq!(
+            checked_upload_size(i64::MAX, "size").expect("i64 max is representable"),
+            i64::MAX as u64
+        );
+        assert!(checked_upload_size(-1, "size").is_err());
+    }
     use tokio::sync::Barrier;
 
     struct AtomicAttemptDriver {
@@ -559,5 +730,72 @@ mod tests {
         .await
         .expect("independent attempts must not be serialized");
         assert_eq!(driver.max_active.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn exact_size_reader_rejects_short_and_long_streams_before_completion() {
+        let mut short = ExactSizeReader::new(std::io::Cursor::new(b"abc"), 4);
+        let short_error = tokio::io::AsyncReadExt::read_to_end(&mut short, &mut Vec::new())
+            .await
+            .expect_err("short reader should fail");
+        assert_eq!(short_error.kind(), std::io::ErrorKind::UnexpectedEof);
+
+        let mut long = ExactSizeReader::new(std::io::Cursor::new(b"abcde"), 4);
+        let long_error = tokio::io::AsyncReadExt::read_to_end(&mut long, &mut Vec::new())
+            .await
+            .expect_err("long reader should fail");
+        assert_eq!(long_error.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[tokio::test]
+    async fn exact_size_reader_rejects_long_stream_while_consumer_reads_declared_bytes() {
+        let mut reader = ExactSizeReader::new(std::io::Cursor::new(b"abcde"), 4);
+        let mut declared = [0_u8; 4];
+        let error = tokio::io::AsyncReadExt::read_exact(&mut reader, &mut declared)
+            .await
+            .expect_err("oversized stream must fail before the fourth byte is released");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(&declared[..3], b"abc");
+    }
+
+    #[tokio::test]
+    async fn exact_size_reader_preserves_data_across_pending_poll() {
+        let mut reader = ExactSizeReader::new(
+            PendingOnceReader {
+                inner: Cursor::new(b"abcd".to_vec()),
+                pending: true,
+            },
+            4,
+        );
+        let mut data = Vec::new();
+        tokio::io::AsyncReadExt::read_to_end(&mut reader, &mut data)
+            .await
+            .expect("pending reader should resume");
+        assert_eq!(data, b"abcd");
+    }
+
+    #[tokio::test]
+    async fn exact_size_reader_preserves_transient_reader_errors() {
+        let mut reader = ExactSizeReader::new(ErrorReader, 1);
+        let error = tokio::io::AsyncReadExt::read_to_end(&mut reader, &mut Vec::new())
+            .await
+            .expect_err("reader failure should be returned");
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert_eq!(error.to_string(), "synthetic reader failure");
+    }
+
+    #[tokio::test]
+    async fn exact_size_reader_probes_zero_and_huge_declarations_without_allocation() {
+        let mut zero = ExactSizeReader::new(std::io::Cursor::new(b"x"), 0);
+        let error = tokio::io::AsyncReadExt::read_to_end(&mut zero, &mut Vec::new())
+            .await
+            .expect_err("zero-size reader with data should fail");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+
+        let mut huge = ExactSizeReader::new(tokio::io::repeat(0), 10 * 1024 * 1024 * 1024 * 1024);
+        let mut one = [0_u8; 1];
+        tokio::io::AsyncReadExt::read_exact(&mut huge, &mut one)
+            .await
+            .expect("huge declaration should stream one byte");
     }
 }

--- a/crates/aster_drive_storage/src/traits/mod.rs
+++ b/crates/aster_drive_storage/src/traits/mod.rs
@@ -9,12 +9,13 @@ pub use driver::{
     PresignedUploadRequest, StorageDriver, StoragePathVisitor,
 };
 pub use extensions::{
-    DirectDownloadStorageDriver, ListStorageDriver, LocalPathStorageDriver,
+    DirectDownloadStorageDriver, ExactSizeReader, ListStorageDriver, LocalPathStorageDriver,
     NativeMediaMetadataRequest, NativeMediaMetadataResult, NativeMediaMetadataStorageDriver,
     NativeThumbnailRequest, NativeThumbnailStorageDriver, PresignedUploadStorageDriver,
     ProviderResumableUploadCapabilities, ProviderResumableUploadDriver,
     ProviderResumableUploadFragmentOutcome, ProviderResumableUploadSession,
     ProviderResumableUploadStatus, StorageCapacityInfo, StorageCapacityStatus,
     StorageDriverExtensions, StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver,
+    checked_upload_size, exact_size_error_kind,
 };
 pub use multipart::{MultipartStorageDriver, UploadedMultipartPart};

--- a/crates/aster_drive_storage/src/traits/multipart.rs
+++ b/crates/aster_drive_storage/src/traits/multipart.rs
@@ -11,12 +11,14 @@
 
 use crate::error::{MapStorageErr, Result, StorageErrorKind, storage_driver_error};
 use crate::traits::driver::PresignedUploadRequest;
+use crate::traits::extensions::checked_upload_size;
 use async_trait::async_trait;
 use bytes::Bytes;
 use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 const DEFAULT_MULTIPART_READER_BUFFER_SIZE: usize = 64 * 1024;
+const MAX_DEFAULT_MULTIPART_READER_SIZE: usize = 64 * 1024 * 1024;
 
 /// Provider 端已经接收的 multipart part 明细。
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -90,8 +92,20 @@ pub trait MultipartStorageDriver: Send + Sync {
         size: i64,
     ) -> Result<String> {
         let mut reader = reader;
-        let expected_size = aster_forge_utils::numbers::bytes_to_usize(size, "multipart part size")
-            .map_storage_err(StorageErrorKind::Misconfigured)?;
+        let expected_size = checked_upload_size(size, "multipart part size").and_then(|size| {
+            usize::try_from(size).map_err(|error| {
+                storage_driver_error(
+                    StorageErrorKind::Misconfigured,
+                    format!("multipart part size conversion failed: {error}"),
+                )
+            })
+        })?;
+        if expected_size > MAX_DEFAULT_MULTIPART_READER_SIZE {
+            return Err(storage_driver_error(
+                StorageErrorKind::Unsupported,
+                "multipart reader fallback exceeds the 64 MiB buffer budget",
+            ));
+        }
         let mut data = Vec::with_capacity(expected_size);
         let mut buffer = vec![0u8; DEFAULT_MULTIPART_READER_BUFFER_SIZE.min(expected_size.max(1))];
 
@@ -110,7 +124,7 @@ pub trait MultipartStorageDriver: Send + Sync {
 
         if data.len() < expected_size {
             return Err(storage_driver_error(
-                StorageErrorKind::Transient,
+                StorageErrorKind::Precondition,
                 format!(
                     "read multipart part stream: multipart part stream ended before expected size {size}"
                 ),
@@ -124,7 +138,7 @@ pub trait MultipartStorageDriver: Send + Sync {
             .map_storage_err_ctx(StorageErrorKind::Transient, "read multipart part stream")?;
         if extra_read > 0 {
             return Err(storage_driver_error(
-                StorageErrorKind::Transient,
+                StorageErrorKind::Precondition,
                 format!(
                     "read multipart part stream: multipart part stream exceeds expected size {size}"
                 ),
@@ -265,7 +279,7 @@ mod tests {
             .await
             .expect_err("oversized stream should fail");
 
-        assert_eq!(error.kind(), StorageErrorKind::Transient);
+        assert_eq!(error.kind(), StorageErrorKind::Precondition);
         assert!(
             error
                 .message()
@@ -295,7 +309,7 @@ mod tests {
             .await
             .expect_err("short stream should fail");
 
-        assert_eq!(error.kind(), StorageErrorKind::Transient);
+        assert_eq!(error.kind(), StorageErrorKind::Precondition);
         assert!(
             error
                 .message()
@@ -350,7 +364,7 @@ mod tests {
             .await
             .expect_err("zero-size stream with data should fail");
 
-        assert_eq!(error.kind(), StorageErrorKind::Transient);
+        assert_eq!(error.kind(), StorageErrorKind::Precondition);
         assert!(
             error
                 .message()
@@ -380,7 +394,7 @@ mod tests {
             .await
             .expect_err("negative size should fail");
 
-        assert_eq!(error.kind(), StorageErrorKind::Misconfigured);
+        assert_eq!(error.kind(), StorageErrorKind::Precondition);
         assert!(
             driver
                 .uploaded
@@ -388,5 +402,23 @@ mod tests {
                 .expect("uploaded lock should not poison")
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn default_reader_upload_rejects_unbounded_buffer_requests() {
+        let driver = CapturingMultipartDriver::new();
+
+        let error = driver
+            .upload_multipart_part_reader(
+                "path",
+                "upload",
+                1,
+                Box::new(tokio::io::empty()),
+                (MAX_DEFAULT_MULTIPART_READER_SIZE as i64) + 1,
+            )
+            .await
+            .expect_err("fallback must enforce its memory budget");
+
+        assert_eq!(error.kind(), StorageErrorKind::Unsupported);
     }
 }

--- a/src/storage/connectors/tests.rs
+++ b/src/storage/connectors/tests.rs
@@ -36,6 +36,34 @@ struct LocalizationContractConnector {
 #[test]
 fn unified_registry_exposes_remote_target_scope_for_reusable_provider_connectors() {
     let registry = builtin_storage_connector_registry().expect("built-in registry");
+    let ids = registry
+        .descriptors()
+        .into_iter()
+        .map(|descriptor| descriptor.connector_id.to_string())
+        .collect::<HashSet<_>>();
+    assert_eq!(
+        ids.len(),
+        10,
+        "the built-in connector matrix must stay complete"
+    );
+    assert_eq!(
+        ids,
+        [
+            "asterdrive.storage.local",
+            "asterdrive.storage.s3",
+            "asterdrive.storage.alibaba_oss",
+            "asterdrive.storage.sftp",
+            "asterdrive.storage.azure_blob",
+            "asterdrive.storage.huawei_obs",
+            "asterdrive.storage.tencent_cos",
+            "asterdrive.storage.remote",
+            "asterdrive.storage.onedrive",
+            "asterdrive.storage.qiniu",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+    );
     for connector_id in [
         "asterdrive.storage.local",
         "asterdrive.storage.s3",

--- a/src/storage/drivers/azure_blob/mod.rs
+++ b/src/storage/drivers/azure_blob/mod.rs
@@ -441,8 +441,16 @@ impl AzureBlobDriver {
     }
 
     fn map_azure_error(ctx: &str, error: azure_core::Error) -> StorageError {
-        let kind = Self::classify_azure_error(&error);
-        storage_driver_error(kind, format!("{ctx}: {}", Self::format_azure_error(error)))
+        let marker = error.to_string();
+        let kind = if marker.contains("reader exceeded declared size")
+            || marker.contains("reader ended before declared size")
+        {
+            StorageErrorKind::Precondition
+        } else {
+            Self::classify_azure_error(&error)
+        };
+        let detail = Self::format_azure_error(error);
+        storage_driver_error(kind, format!("{ctx}: {detail}"))
     }
 
     fn rewrap_azure_error(ctx: &str, error: azure_core::Error) -> StorageError {

--- a/src/storage/drivers/azure_blob/multipart.rs
+++ b/src/storage/drivers/azure_blob/multipart.rs
@@ -13,7 +13,9 @@ use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, ReadBuf};
 
 use aster_drive_storage::traits::driver::StorageDriver;
-use aster_drive_storage::traits::extensions::StreamUploadDriver;
+use aster_drive_storage::traits::extensions::{
+    ExactSizeReader, StreamUploadDriver, checked_upload_size,
+};
 use aster_drive_storage::traits::multipart::{MultipartStorageDriver, UploadedMultipartPart};
 use aster_drive_storage::{MapStorageErr, StorageError, StorageErrorKind, storage_driver_error};
 use aster_forge_utils::numbers;
@@ -324,13 +326,13 @@ impl MultipartStorageDriver for AzureBlobDriver {
         size: i64,
     ) -> aster_drive_storage::Result<String> {
         let client = self.block_blob_client(path, "cw")?;
-        let content_length =
-            aster_forge_utils::numbers::i64_to_u64(size, "Azure Blob multipart part size")
-                .map_storage_err(StorageErrorKind::Misconfigured)?;
-        let body: RequestContent<Bytes, azure_core::http::NoFormat> = Body::SeekableStream(
-            Box::new(AzureSizedReaderStream::new(reader, content_length)),
-        )
-        .into();
+        let content_length = checked_upload_size(size, "Azure Blob multipart part size")?;
+        let body: RequestContent<Bytes, azure_core::http::NoFormat> =
+            Body::SeekableStream(Box::new(AzureSizedReaderStream::new(
+                Box::new(ExactSizeReader::new(reader, content_length)),
+                content_length,
+            )))
+            .into();
         client
             .stage_block(
                 &Self::block_id(upload_id, part_number)?,
@@ -408,18 +410,30 @@ impl StreamUploadDriver for AzureBlobDriver {
         reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
         size: i64,
     ) -> aster_drive_storage::Result<String> {
-        let expected_size = numbers::i64_to_u64(size, "Azure Blob put_reader declared size")
-            .map_storage_err(StorageErrorKind::Misconfigured)?;
+        let expected_size = checked_upload_size(size, "Azure Blob put_reader declared size")?;
         let chunk_size = self.chunk_size_for_content(expected_size)?;
+        if expected_size == 0 {
+            let mut reader = reader;
+            let mut probe = [0_u8; 1];
+            let read = tokio::io::AsyncReadExt::read(&mut reader, &mut probe)
+                .await
+                .map_storage_err_ctx(
+                    StorageErrorKind::Transient,
+                    "check Azure Blob zero-size upload",
+                )?;
+            if read != 0 {
+                return Err(storage_driver_error(
+                    StorageErrorKind::Precondition,
+                    "Azure Blob upload stream exceeded declared size",
+                ));
+            }
+            self.put(storage_path, &[]).await?;
+            return Ok(storage_path.to_string());
+        }
         let reader = Arc::new(Mutex::new(reader));
         let mut remaining = expected_size;
         let mut part_number = 1_i32;
         let mut parts = Vec::new();
-
-        if remaining == 0 {
-            self.put(storage_path, &[]).await?;
-            return Ok(storage_path.to_string());
-        }
 
         let upload_id = self.create_multipart_upload(storage_path).await?;
         while remaining > 0 {

--- a/src/storage/drivers/local/stream_upload.rs
+++ b/src/storage/drivers/local/stream_upload.rs
@@ -1,11 +1,11 @@
 use async_trait::async_trait;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncWriteExt};
 
 use aster_drive_storage::traits::extensions::{
-    StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver,
+    ExactSizeReader, StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver,
+    checked_upload_size, exact_size_error_kind,
 };
 use aster_drive_storage::{MapStorageErr, StorageErrorKind, storage_driver_error};
-use aster_forge_utils::numbers;
 
 use super::LocalDriver;
 
@@ -46,8 +46,7 @@ impl StreamUploadDriver for LocalDriver {
         reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
     ) -> aster_drive_storage::Result<()> {
         let expected_size =
-            numbers::i64_to_u64(attempt.expected_size, "local stream upload declared size")
-                .map_storage_err(StorageErrorKind::Misconfigured)?;
+            checked_upload_size(attempt.expected_size, "local stream upload declared size")?;
         let staging_path = self.full_path(&attempt.staging_path)?;
         if let Some(parent) = staging_path.parent() {
             tokio::fs::create_dir_all(parent)
@@ -55,21 +54,18 @@ impl StreamUploadDriver for LocalDriver {
                 .map_storage_err(StorageErrorKind::Transient)?;
         }
 
-        let mut reader = reader;
+        let mut reader = ExactSizeReader::new(reader, expected_size);
         let mut file = tokio::fs::File::create(&staging_path)
             .await
             .map_storage_err(StorageErrorKind::Transient)?;
-        let written =
-            match tokio::io::copy(&mut (&mut *reader).take(expected_size), &mut file).await {
-                Ok(written) => written,
-                Err(error) => {
-                    cleanup_local_staging_file(&staging_path, "reader error").await;
-                    return Err(error).map_storage_err_ctx(
-                        StorageErrorKind::Transient,
-                        "write local upload attempt",
-                    );
-                }
-            };
+        let written = match tokio::io::copy(&mut reader, &mut file).await {
+            Ok(written) => written,
+            Err(error) => {
+                cleanup_local_staging_file(&staging_path, "reader error").await;
+                let kind = exact_size_error_kind(&error).unwrap_or(StorageErrorKind::Transient);
+                return Err(error).map_storage_err_ctx(kind, "write local upload attempt");
+            }
+        };
         if written != expected_size {
             cleanup_local_staging_file(&staging_path, "size mismatch").await;
             return Err(storage_driver_error(
@@ -79,27 +75,6 @@ impl StreamUploadDriver for LocalDriver {
                     attempt.expected_size
                 ),
             ));
-        }
-        let mut extra = [0_u8; 1];
-        match reader.read(&mut extra).await {
-            Ok(0) => {}
-            Ok(_) => {
-                cleanup_local_staging_file(&staging_path, "size mismatch").await;
-                return Err(storage_driver_error(
-                    StorageErrorKind::Precondition,
-                    format!(
-                        "local stream upload size mismatch: declared {}, actual exceeds declared size",
-                        attempt.expected_size
-                    ),
-                ));
-            }
-            Err(error) => {
-                cleanup_local_staging_file(&staging_path, "length probe error").await;
-                return Err(error).map_storage_err_ctx(
-                    StorageErrorKind::Transient,
-                    "check local upload attempt length",
-                );
-            }
         }
         if let Err(error) = file.flush().await {
             cleanup_local_staging_file(&staging_path, "flush error").await;

--- a/src/storage/drivers/onedrive/error.rs
+++ b/src/storage/drivers/onedrive/error.rs
@@ -16,6 +16,15 @@ pub(super) struct MicrosoftGraphErrorBody {
 }
 
 pub(super) fn map_reqwest_error(ctx: &str, error: reqwest::Error) -> StorageError {
+    let message = error.to_string();
+    if message.contains("reader exceeded declared size")
+        || message.contains("reader ended before declared size")
+    {
+        return storage_driver_error(
+            StorageErrorKind::Precondition,
+            format!("{ctx}: Microsoft Graph upload stream length mismatch: {message}"),
+        );
+    }
     if error.is_timeout() {
         return storage_driver_error(
             StorageErrorKind::Transient,

--- a/src/storage/drivers/onedrive/mod.rs
+++ b/src/storage/drivers/onedrive/mod.rs
@@ -10,10 +10,11 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 
 use aster_drive_storage::traits::driver::{BlobMetadata, StorageDriver};
 use aster_drive_storage::traits::extensions::{
-    DirectDownloadStorageDriver, ProviderResumableUploadCapabilities,
+    DirectDownloadStorageDriver, ExactSizeReader, ProviderResumableUploadCapabilities,
     ProviderResumableUploadDriver, ProviderResumableUploadFragmentOutcome,
     ProviderResumableUploadSession, ProviderResumableUploadStatus, StorageCapacityInfo,
-    StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver,
+    StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver, checked_upload_size,
+    exact_size_error_kind,
 };
 use aster_drive_storage::{
     MapStorageErr, Result, StorageError, StorageErrorKind, storage_driver_error,
@@ -262,13 +263,20 @@ impl OneDriveDriver {
     async fn put_reader_via_upload_session(
         &self,
         path: &str,
-        mut reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
+        reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
         size: i64,
         attempt: Option<&StreamUploadAttempt>,
     ) -> Result<String> {
-        let total_size = numbers::i64_to_u64(size, "OneDrive put_reader declared size")
-            .map_storage_err(StorageErrorKind::Misconfigured)?;
+        let total_size = checked_upload_size(size, "OneDrive put_reader declared size")?;
+        let mut reader = ExactSizeReader::new(reader, total_size);
         if total_size == 0 {
+            let mut probe = [0_u8; 1];
+            reader.read(&mut probe).await.map_err(|error| {
+                storage_driver_error(
+                    exact_size_error_kind(&error).unwrap_or(StorageErrorKind::Transient),
+                    format!("read OneDrive zero-size upload stream: {error}"),
+                )
+            })?;
             return self
                 .put_owned_with_attempt(path, Bytes::new(), attempt)
                 .await;
@@ -277,11 +285,13 @@ impl OneDriveDriver {
             let capacity = numbers::u64_to_usize(total_size, "OneDrive bounded simple upload size")
                 .map_storage_err(StorageErrorKind::Misconfigured)?;
             let mut data = vec![0_u8; capacity];
-            reader.read_exact(&mut data).await.map_storage_err_ctx(
-                StorageErrorKind::Precondition,
-                "read OneDrive bounded simple upload stream",
-            )?;
-            reject_extra_upload_bytes(reader).await?;
+            reader.read_exact(&mut data).await.map_err(|error| {
+                let kind = exact_size_error_kind(&error).unwrap_or(StorageErrorKind::Transient);
+                storage_driver_error(
+                    kind,
+                    format!("read OneDrive bounded simple upload stream: {error}"),
+                )
+            })?;
             return self
                 .put_owned_with_attempt(path, Bytes::from(data), attempt)
                 .await;
@@ -314,10 +324,13 @@ impl OneDriveDriver {
                 )
                 .map_storage_err(StorageErrorKind::Misconfigured)?;
                 let mut chunk = vec![0_u8; read_len];
-                reader.read_exact(&mut chunk).await.map_storage_err_ctx(
-                    StorageErrorKind::Precondition,
-                    "read OneDrive upload session fragment",
-                )?;
+                reader.read_exact(&mut chunk).await.map_err(|error| {
+                    let kind = exact_size_error_kind(&error).unwrap_or(StorageErrorKind::Transient);
+                    storage_driver_error(
+                        kind,
+                        format!("read OneDrive upload session fragment: {error}"),
+                    )
+                })?;
                 if remaining
                     > numbers::usize_to_u64(read_len, "OneDrive upload fragment length")
                         .map_storage_err(StorageErrorKind::Misconfigured)?
@@ -339,7 +352,6 @@ impl OneDriveDriver {
                 uploaded += numbers::usize_to_u64(read_len, "OneDrive uploaded fragment size")
                     .map_storage_err(StorageErrorKind::Misconfigured)?;
             }
-            reject_extra_upload_bytes(reader).await?;
             Ok(path.to_string())
         }
         .await;
@@ -702,23 +714,6 @@ impl ProviderResumableUploadDriver for OneDriveDriver {
             next_expected_ranges: outcome.next_expected_ranges,
         })
     }
-}
-
-async fn reject_extra_upload_bytes(
-    mut reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
-) -> Result<()> {
-    let mut extra = [0_u8; 1];
-    let read = reader.read(&mut extra).await.map_storage_err_ctx(
-        StorageErrorKind::Precondition,
-        "check OneDrive upload stream length",
-    )?;
-    if read != 0 {
-        return Err(storage_driver_error(
-            StorageErrorKind::Misconfigured,
-            "OneDrive upload stream exceeded declared size",
-        ));
-    }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -1280,7 +1275,7 @@ mod tests {
             )
             .await
             .expect_err("extra reader bytes must be rejected");
-        assert_eq!(long.kind(), StorageErrorKind::Misconfigured);
+        assert_eq!(long.kind(), StorageErrorKind::Precondition);
 
         assert!(
             server

--- a/src/storage/drivers/remote/stream_upload.rs
+++ b/src/storage/drivers/remote/stream_upload.rs
@@ -1,10 +1,9 @@
 use std::path::Path;
 
+use aster_drive_storage::error::{StorageErrorKind, storage_driver_error};
+use aster_drive_storage::traits::extensions::{StreamUploadDriver, checked_upload_size};
 use async_trait::async_trait;
 use tokio::io::AsyncRead;
-
-use aster_drive_storage::error::{StorageErrorKind, storage_driver_error};
-use aster_drive_storage::traits::extensions::StreamUploadDriver;
 
 use super::RemoteDriver;
 
@@ -16,12 +15,7 @@ impl StreamUploadDriver for RemoteDriver {
         reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
         size: i64,
     ) -> aster_drive_storage::Result<String> {
-        let size = u64::try_from(size).map_err(|_| {
-            storage_driver_error(
-                StorageErrorKind::Precondition,
-                format!("remote stream upload size must be non-negative, got {size}"),
-            )
-        })?;
+        let size = checked_upload_size(size, "remote stream upload size")?;
         self.client
             .put_reader(&self.object_key(storage_path), reader, size)
             .await?;

--- a/src/storage/drivers/s3/error.rs
+++ b/src/storage/drivers/s3/error.rs
@@ -141,8 +141,15 @@ impl S3Driver {
     where
         E: StdError + ProvideErrorMetadata + Send + Sync + 'static,
     {
-        let kind = Self::classify_sdk_error(&err);
-        storage_driver_error(kind, format!("{ctx}: {}", Self::format_sdk_error(&err)))
+        let detail = Self::format_sdk_error(&err);
+        let kind = if detail.contains("reader exceeded declared size")
+            || detail.contains("reader ended before declared size")
+        {
+            StorageErrorKind::Precondition
+        } else {
+            Self::classify_sdk_error(&err)
+        };
+        storage_driver_error(kind, format!("{ctx}: {detail}"))
     }
 
     pub(super) fn classify_sdk_error<E>(err: &SdkError<E>) -> StorageErrorKind

--- a/src/storage/drivers/s3/multipart.rs
+++ b/src/storage/drivers/s3/multipart.rs
@@ -1,14 +1,14 @@
 use std::time::Duration;
 
+use aster_drive_storage::PresignedUploadRequest;
+use aster_drive_storage::traits::extensions::{ExactSizeReader, checked_upload_size};
+use aster_drive_storage::traits::multipart::{MultipartStorageDriver, UploadedMultipartPart};
+use aster_drive_storage::{MapStorageErr, StorageErrorKind, storage_driver_error};
 use async_trait::async_trait;
 use aws_sdk_s3::presigning::PresigningConfig;
 use aws_sdk_s3::primitives::ByteStream;
 use bytes::Bytes;
 use tokio::io::AsyncRead;
-
-use aster_drive_storage::PresignedUploadRequest;
-use aster_drive_storage::traits::multipart::{MultipartStorageDriver, UploadedMultipartPart};
-use aster_drive_storage::{MapStorageErr, StorageErrorKind, storage_driver_error};
 
 use super::S3Driver;
 use super::presigned::{clamp_presign_ttl, sdk_presigned_upload_request};
@@ -155,10 +155,9 @@ impl MultipartStorageDriver for S3Driver {
         size: i64,
     ) -> aster_drive_storage::Result<String> {
         let key = self.full_key(path);
-        let content_length = aster_forge_utils::numbers::i64_to_u64(size, "S3 multipart part size")
-            .map_storage_err(StorageErrorKind::Misconfigured)?;
+        let content_length = checked_upload_size(size, "S3 multipart part size")?;
         let body = ByteStream::from_body_1_x(super::stream_upload::SizedReaderBody::new(
-            reader,
+            ExactSizeReader::new(reader, content_length),
             content_length,
         ));
         let resp = self

--- a/src/storage/drivers/s3/stream_upload.rs
+++ b/src/storage/drivers/s3/stream_upload.rs
@@ -9,7 +9,9 @@ use http_body::{Frame, SizeHint};
 use tokio::io::AsyncRead;
 use tokio_util::io::ReaderStream;
 
-use aster_drive_storage::traits::extensions::StreamUploadDriver;
+use aster_drive_storage::traits::extensions::{
+    ExactSizeReader, StreamUploadDriver, checked_upload_size,
+};
 use aster_drive_storage::{MapStorageErr, StorageErrorKind};
 use aster_forge_utils::numbers;
 
@@ -140,9 +142,11 @@ impl StreamUploadDriver for S3Driver {
         size: i64,
     ) -> aster_drive_storage::Result<String> {
         let key = self.full_key(storage_path);
-        let content_length = numbers::i64_to_u64(size, "S3 put_reader content_length")
-            .map_storage_err(StorageErrorKind::Misconfigured)?;
-        let body = ByteStream::from_body_1_x(SizedReaderBody::new(reader, content_length));
+        let content_length = checked_upload_size(size, "S3 put_reader content_length")?;
+        let body = ByteStream::from_body_1_x(SizedReaderBody::new(
+            ExactSizeReader::new(reader, content_length),
+            content_length,
+        ));
 
         self.client
             .put_object()

--- a/src/storage/drivers/sftp.rs
+++ b/src/storage/drivers/sftp.rs
@@ -21,7 +21,8 @@ use aster_drive_storage::error::{
     storage_driver_error_with_context,
 };
 use aster_drive_storage::{
-    BlobMetadata, StorageDriver, StreamUploadAttempt, StreamUploadCleanup, StreamUploadDriver,
+    BlobMetadata, ExactSizeReader, StorageDriver, StreamUploadAttempt, StreamUploadCleanup,
+    StreamUploadDriver,
 };
 
 const DEFAULT_SFTP_PORT: u16 = 22;
@@ -603,7 +604,7 @@ impl StreamUploadDriver for SftpDriver {
     async fn put_reader(
         &self,
         storage_path: &str,
-        mut reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
+        reader: Box<dyn AsyncRead + Unpin + Send + Sync>,
         size: i64,
     ) -> aster_drive_storage::Result<String> {
         let remote_path = self.full_path(storage_path)?;
@@ -624,6 +625,7 @@ impl StreamUploadDriver for SftpDriver {
             .create(temporary_path.clone())
             .await
             .map_err(|error| connection.map_sftp_error("SFTP create failed", error))?;
+        let mut reader = ExactSizeReader::new(reader, expected_size);
         let written = match tokio::io::copy(&mut reader, &mut remote_file).await {
             Ok(written) => written,
             Err(error) => {
@@ -1199,6 +1201,16 @@ fn is_sftp_connection_reusable_after_error(error: &SftpError) -> bool {
 }
 
 fn classify_io_error(error: &std::io::Error) -> StorageErrorKind {
+    if matches!(
+        error.kind(),
+        std::io::ErrorKind::UnexpectedEof | std::io::ErrorKind::InvalidData
+    ) && (error
+        .to_string()
+        .contains("reader ended before declared size")
+        || error.to_string().contains("reader exceeded declared size"))
+    {
+        return StorageErrorKind::Precondition;
+    }
     match error.kind() {
         std::io::ErrorKind::NotFound => StorageErrorKind::NotFound,
         std::io::ErrorKind::PermissionDenied => StorageErrorKind::Permission,

--- a/src/storage/remote_protocol/errors.rs
+++ b/src/storage/remote_protocol/errors.rs
@@ -10,16 +10,23 @@ struct RemoteErrorEnvelope {
 }
 
 pub(super) fn map_reqwest_error(error: reqwest::Error) -> AsterError {
-    if error.is_timeout() {
+    let message = error.to_string();
+    let kind = if message.contains("reader exceeded declared size")
+        || message.contains("reader ended before declared size")
+    {
+        StorageErrorKind::Precondition
+    } else if error.is_timeout() || error.is_connect() || error.is_request() {
+        StorageErrorKind::Transient
+    } else {
+        StorageErrorKind::Unknown
+    };
+    if kind == StorageErrorKind::Transient && error.is_timeout() {
         crate::errors::storage_driver_error(
             StorageErrorKind::Transient,
             format!("remote storage request timed out: {error}"),
         )
     } else {
-        crate::errors::storage_driver_error(
-            StorageErrorKind::Transient,
-            format!("remote storage request failed: {error}"),
-        )
+        crate::errors::storage_driver_error(kind, format!("remote storage request failed: {error}"))
     }
 }
 

--- a/src/storage/remote_protocol/transport.rs
+++ b/src/storage/remote_protocol/transport.rs
@@ -12,7 +12,7 @@ use tokio_util::io::{ReaderStream, StreamReader};
 use crate::config::OUTBOUND_HTTP_USER_AGENT;
 use crate::errors::{AsterError, Result};
 use aster_drive_model::entities::managed_follower;
-use aster_drive_storage::StorageErrorKind;
+use aster_drive_storage::{ExactSizeReader, StorageErrorKind};
 
 use super::auth::{normalize_remote_base_url, sign_internal_request};
 use super::errors::{build_remote_status_error_from_parts, map_reqwest_error};
@@ -66,7 +66,7 @@ impl RemoteRequestBody {
         match self {
             Self::Empty => Ok(Box::new(std::io::Cursor::new(Bytes::new()))),
             Self::Bytes(body) => Ok(Box::new(std::io::Cursor::new(body))),
-            Self::Reader { reader, .. } => Ok(reader),
+            Self::Reader { reader, size } => Ok(Box::new(ExactSizeReader::new(reader, size))),
         }
     }
 
@@ -230,8 +230,9 @@ impl RemoteTransport for DirectHttpTransport {
         builder = match request.body {
             RemoteRequestBody::Empty => builder,
             RemoteRequestBody::Bytes(body) => builder.body(body),
-            RemoteRequestBody::Reader { reader, .. } => {
-                let stream = ReaderStream::new(reader).map_err(std::io::Error::other);
+            RemoteRequestBody::Reader { reader, size } => {
+                let stream = ReaderStream::new(ExactSizeReader::new(reader, size))
+                    .map_err(std::io::Error::other);
                 builder.body(reqwest::Body::wrap_stream(stream))
             }
         };

--- a/tests/storage/storage_multipart.rs
+++ b/tests/storage/storage_multipart.rs
@@ -112,7 +112,7 @@ async fn default_reader_upload_rejects_stream_larger_than_size() {
         .await
         .expect_err("oversized stream should fail");
 
-    assert_eq!(error.kind(), StorageErrorKind::Transient);
+    assert_eq!(error.kind(), StorageErrorKind::Precondition);
     assert!(
         error
             .message()
@@ -136,7 +136,7 @@ async fn default_reader_upload_rejects_stream_shorter_than_size() {
         .await
         .expect_err("short stream should fail");
 
-    assert_eq!(error.kind(), StorageErrorKind::Transient);
+    assert_eq!(error.kind(), StorageErrorKind::Precondition);
     assert!(
         error
             .message()
@@ -172,7 +172,7 @@ async fn default_reader_upload_enforces_zero_size_boundary() {
         .await
         .expect_err("zero-size stream with data should fail");
 
-    assert_eq!(error.kind(), StorageErrorKind::Transient);
+    assert_eq!(error.kind(), StorageErrorKind::Precondition);
     assert!(
         error
             .message()
@@ -196,6 +196,6 @@ async fn default_reader_upload_rejects_negative_size_before_upload() {
         .await
         .expect_err("negative size should fail");
 
-    assert_eq!(error.kind(), StorageErrorKind::Misconfigured);
+    assert_eq!(error.kind(), StorageErrorKind::Precondition);
     assert!(driver.uploaded().is_empty());
 }


### PR DESCRIPTION
## 变更

Closes #512

- 引入公共 `checked_upload_size` 与 `ExactSizeReader`，在释放声明长度最后一个字节前探测额外输入。
- 迁移 S3、Azure Blob、Local、SFTP、Remote、OneDrive 六条真实 reader runtime 路径；S3-compatible connector 继续统一委托。
- 修复 Azure/OneDrive 零长度快速路径、OneDrive 最后 fragment、SFTP 临时对象无界增长。
- 统一 exact reader 短/长流错误为 `Precondition`，普通 I/O/网络错误保持 `Transient`。
- multipart 默认 reader fallback 增加 64 MiB 内存预算，超预算返回 `Unsupported`。
- 增加 10 connector 注册矩阵断言和固定 Content-Length consumer 边界测试。

## 验证

- `cargo check --all-targets`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p aster_drive_storage --lib`（73 passed）
- exact-size/multipart focused tests（10 passed）
- connector registry focused test（1 passed）
- storage integration target 已编译并跑过大部分用例，Azurite Azure boundary/E2E、Remote truncated/zero-byte/compose、SFTP negative-size、Qiniu wrapper 等相关用例通过；剩余长耗时数据库/远端用例在本地命令窗口到期，未将其计为整 target 全绿。
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 强化各类存储连接器的上传长度校验，及时识别上传内容过短或超出声明大小的情况。
  - 负数或超大上传大小将被拒绝，避免不合理的内存分配。
  - 统一将上传长度不匹配报告为前置条件错误，提升错误提示和处理一致性。
  - 改进零字节上传的校验，确保空文件与非空内容正确区分。

- **测试**
  - 增加连接器注册完整性及上传边界场景测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->